### PR TITLE
ドキュメントおよびコメントの拡充と見直し

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ exporter.Export(folderPath, jsonFilePath);
 
 `-r`を指定するとサブフォルダまで対象にできます。
 
+| ReviewFileToJson.exe -f folder -u
+
+`-u`を指定すると出力されるJSONファイルにおいてUnicodeエスケープを行いません。
+
+### `-u`オプションの注意点
+本オプションをつけることで出力されるJSONファイルはUTF-8でエンコードされたJSONファイルとなります。  
+以下はJSONファイルの指摘の重大度の出力イメージ例
+
+```
+"Importance": "\u4E2D" // -u オプションをつけず、Unicodeエスケープされた状態
+"Importance": "中"     // -u オプションをつけて、UTF-8で出力された状態
+```
+
+-uをつけて出力されたJSONファイルを別ツールで読み込む場合は、ファイル内容がうまく読み取れなくなる恐れがあるため、UTF-8で読み込む必要があることに注意してください。
+
 ### 出力されるJSONファイルのフォーマット
 
 ``` 
@@ -183,6 +198,3 @@ exporter.Export(folderPath, jsonFilePath);
 フィールド情報の詳細は下記クラスに記載してあります。
 - レビューのフィールド情報について: [Review.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Review.cs)
 - 指摘のフィールド情報について: [Issue.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Issue.cs)
-
-### 補足
-ReviewFileToJsonCLIを用いて出力されるJSONファイルはUTF-8でエンコードされたJSONファイルとなっているため、出力されたJSONファイルを別ツールで読み込む場合は、UTF-8で読み込む必要があることに注意してください。

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Console.WriteLine(review.PlannedDate);
 // レビューが持つ指摘を取得する
 foreach (var issue in review.Issues)
 {
-	// 指摘のステータス
-	Console.WriteLine(issue.Status);
+    // 指摘のステータス
+    Console.WriteLine(issue.Status);
     // 指摘の優先度
-	Console.WriteLine(issue.Priority);
+    Console.WriteLine(issue.Priority);
     // 指摘の修正日
     Console.WriteLine(issue.DateFixed);
 }
@@ -136,7 +136,7 @@ exporter.Export(folderPath, jsonFilePath);
 
 ### 出力されるJSONファイルのフォーマット
 
-```json 
+``` 
 {
     "TotalReviewCount": 3,  // 読みこんだレビューファイルの数
     "TotalIssueCount": 9,   // すべてのレビューファイルの指摘の合計
@@ -178,6 +178,7 @@ exporter.Export(folderPath, jsonFilePath);
     ]
 }
 ``` 
+
 ### 出力フィールドの説明
 フィールド情報の詳細は下記クラスに記載してあります。
 - レビューのフィールド情報について: [Review.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Review.cs)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Console.WriteLine(review.LastUpdatedDateTime);
 // レビューが持つ指摘の要素にアクセスする場合
 foreach (var issue in review.Issues)
 {
-	// 指摘の状態
+	// 指摘のステータス
 	Console.WriteLine(issue.Status);
     // 指摘の優先度
 	Console.WriteLine(issue.Priority);
@@ -145,19 +145,19 @@ exporter.Export(folderPath, jsonFilePath);
             // レビュー①のフィールド情報
             "GID": "b90a3142-2c05-4550-9ac5-008ea6461bc0",
             "FilePath": "C:\\work\\\\RevFile1.revx",
-            // ...
+            //...
             "Issues": [
                 {
                     // レビュー①に関連する指摘①のフィールド情報
                     "GID": "a74cde8d-d7e7-4948-8a60-82f0fabea5f8",
                     "LID": "1",
-                    // ...
+                    //...
                 },
                 {
                     // レビュー①に関連する指摘②のフィールド情報
                     "GID": "4eaf62fa-995a-45f7-9ddf-65e605bfc28c",
                     "LID": "2",
-                    // ...
+                    //...
                 }
             ]  
         },
@@ -165,13 +165,13 @@ exporter.Export(folderPath, jsonFilePath);
             // レビュー②のフィールド情報
             "GID": "b90a3142-2c05-4550-9ac5-008ea6461bc1",
             "FilePath": "C:\\work\\\\RevFile2.revx",
-            // ...
+            //...
             "Issues": [
                 {
                     // レビュー②に関連する指摘①のフィールド情報
                     "GID": "a74cde8d-d7e7-4948-8a60-82f0fabea5f9",
                     "LID": "1",
-                    // ...
+                    //...
                 }
             ]
         }
@@ -179,7 +179,6 @@ exporter.Export(folderPath, jsonFilePath);
 }
 ``` 
 ### 出力フィールドの説明
-フィールド情報の詳細は下記クラスに記載してありますのでそちらを参照ください。
-- レビューのフィールド情報：　　
-  https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Review.cs#L43
-- 指摘のフィールド情報：https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Issue.cs#L35
+フィールド情報の詳細は下記クラスに記載してあります。
+- レビューのフィールド情報について: [Review.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Review.cs)
+- 指摘のフィールド情報について: [Issue.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Issue.cs)

--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ foreach ( var review in reviews)
 
 読み込んだレビューおよび指摘の要素にアクセスする場合
 ```cs
-// レビューの要素にアクセスする場合
+// レビューを取得する
 var review = reader.Read(ReviewFilePath);
 
 // レビューのプロジェクト名
 Console.WriteLine(review.ProjectName);
 // レビューの目標件数
 Console.WriteLine(review.IssueCountOfGoal);
-// レビューの最終更新日時
-Console.WriteLine(review.LastUpdatedDateTime);
+// レビューの計画実施日
+Console.WriteLine(review.PlannedDate);
 
-// レビューが持つ指摘の要素にアクセスする場合
+// レビューが持つ指摘を取得する
 foreach (var issue in review.Issues)
 {
 	// 指摘のステータス
@@ -182,3 +182,6 @@ exporter.Export(folderPath, jsonFilePath);
 フィールド情報の詳細は下記クラスに記載してあります。
 - レビューのフィールド情報について: [Review.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Review.cs)
 - 指摘のフィールド情報について: [Issue.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Issue.cs)
+
+### 補足
+ReviewFileToJsonCLIを用いて出力されるJSONファイルはUTF-8でエンコードされたJSONファイルとなっているため、出力されたJSONファイルを別ツールで読み込む場合は、UTF-8で読み込む必要があることに注意してください。

--- a/README.md
+++ b/README.md
@@ -42,21 +42,21 @@ Console.WriteLine(review.Issues.Count());
 
 フォルダにある複数のレビューファイルを指定する場合
 ```cs
-    // フォルダにある複数のレビューファイルを指定する場合
-    var reviews = reader.ReadFolder(folder);
-    foreach ( var review in reviews)
+// フォルダにある複数のレビューファイルを指定する場合
+var reviews = reader.ReadFolder(folder);
+foreach ( var review in reviews)
+{
+    Console.WriteLine(review.Name);
+
+    // レビューごとの指摘件数
+    Console.WriteLine(review.Issues.Count());
+
+    // 指摘毎の詳細
+    foreach ( var issue in review.Issues)
     {
-        Console.WriteLine(review.Name);
-
-        // レビューごとの指摘件数
-        Console.WriteLine(review.Issues.Count());
-
-        // 指摘毎の詳細
-        foreach ( var issue in review.Issues)
-        {
-            Console.WriteLine(issue.Description);
-        }
+        Console.WriteLine(issue.Description);
     }
+}
 ```
 
 ## LightnigReview.ReviewFileToJsonService
@@ -110,4 +110,52 @@ exporter.Export(folderPath, jsonFilePath);
 
 `-r`を指定するとサブフォルダまで対象にできます。
 
+### 出力されるJSONファイルのフォーマット
 
+```json 
+{
+    "TotalReviewCount": 3,  // 読みこんだレビューファイルの数
+    "TotalIssueCount": 9,   // すべてのレビューファイルの指摘の合計
+    "Reviews": [            // 読み込んだレビューの一覧 
+        {
+            // レビュー①のフィールド情報
+            "GID": "b90a3142-2c05-4550-9ac5-008ea6461bc0",
+            "FilePath": "C:\\work\\\\RevFile1.revx",
+            // ...
+            "Issues": [
+                {
+                    // レビュー①に関連する指摘①のフィールド情報
+                    "GID": "a74cde8d-d7e7-4948-8a60-82f0fabea5f8",
+                    "LID": "1",
+                    // ...
+                },
+                {
+                    // レビュー①に関連する指摘②のフィールド情報
+                    "GID": "4eaf62fa-995a-45f7-9ddf-65e605bfc28c",
+                    "LID": "2",
+                    // ...
+                }
+            ]  
+        },
+        {
+            // レビュー②のフィールド情報
+            "GID": "b90a3142-2c05-4550-9ac5-008ea6461bc1",
+            "FilePath": "C:\\work\\\\RevFile2.revx",
+            // ...
+            "Issues": [
+                {
+                    // レビュー②に関連する指摘①のフィールド情報
+                    "GID": "a74cde8d-d7e7-4948-8a60-82f0fabea5f9",
+                    "LID": "1",
+                    // ...
+                }
+            ]
+        }
+    ]
+}
+``` 
+### 出力フィールドの説明
+フィールド情報の詳細は下記クラスに記載してありますのでそちらを参照ください。
+- レビューのフィールド情報：　　
+  https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Review.cs#L43
+- 指摘のフィールド情報：https://github.com/denso-create/LightningReview-ReviewFile/blob/master/src/ReviewFileToJsonService/Models/Issue.cs#L35

--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ foreach ( var review in reviews)
 }
 ```
 
+読み込んだレビューおよび指摘の要素にアクセスする場合
+```cs
+// レビューの要素にアクセスする場合
+var review = reader.Read(ReviewFilePath);
+
+// レビューのプロジェクト名
+Console.WriteLine(review.ProjectName);
+// レビューの目標件数
+Console.WriteLine(review.IssueCountOfGoal);
+// レビューの最終更新日時
+Console.WriteLine(review.LastUpdatedDateTime);
+
+// レビューが持つ指摘の要素にアクセスする場合
+foreach (var issue in review.Issues)
+{
+	// 指摘の状態
+	Console.WriteLine(issue.Status);
+    // 指摘の優先度
+	Console.WriteLine(issue.Priority);
+    // 指摘の修正日
+    Console.WriteLine(issue.DateFixed);
+}
+```
+
 ## LightnigReview.ReviewFileToJsonService
 
 [![NuGet](https://img.shields.io/nuget/v/LightningReview.ReviewFileToJsonService.svg)](http://nuget.org/packages/LightningReview.ReviewFileToJsonService)

--- a/src/ReviewFile.Tests/Base/TestBase.cs
+++ b/src/ReviewFile.Tests/Base/TestBase.cs
@@ -89,18 +89,18 @@ namespace LightningReview.ReviewFile.Tests
         /// <returns></returns>
         protected IReview ReadReviewStream(string version, string fileName)
         {
-	        var filePath = GetTestDataPath(version, fileName);
-	        using (var archive = ZipFile.OpenRead(filePath))
-	        {
-		        // revxから"Review.xml"を抜き出す
-		        var reviewXmlEntry = archive.GetEntry("Review.xml");
-		        using (var zipEntryStream = reviewXmlEntry.Open())
-		        {
-			        var reader = new ReviewFileReader();
-			        var review = reader.Read(zipEntryStream);
-			        return review;
-		        }
-	        }
+            var filePath = GetTestDataPath(version, fileName);
+            using (var archive = ZipFile.OpenRead(filePath))
+            {
+                // revxから"Review.xml"を抜き出す
+                var reviewXmlEntry = archive.GetEntry("Review.xml");
+                using (var zipEntryStream = reviewXmlEntry.Open())
+                {
+                    var reader = new ReviewFileReader();
+                    var review = reader.Read(zipEntryStream);
+                    return review;
+                }
+            }
         }
     }
 }

--- a/src/ReviewFile.Tests/ReviewFileReaderTests.cs
+++ b/src/ReviewFile.Tests/ReviewFileReaderTests.cs
@@ -47,9 +47,9 @@ namespace LightningReview.ReviewFile.Tests
         [DataTestMethod]
         public void ReadStreamTest(string version)
         {
-	        var review = ReadReviewStream(version, RevFileName);
-	        Assert.IsNotNull(review);
-	        Assert.AreEqual(string.Empty, review.FilePath);
+            var review = ReadReviewStream(version, RevFileName);
+            Assert.IsNotNull(review);
+            Assert.AreEqual(string.Empty, review.FilePath);
         }
 
         [DataRow("V10")]

--- a/src/ReviewFile/Exceptions/RevxFormatException.cs
+++ b/src/ReviewFile/Exceptions/RevxFormatException.cs
@@ -4,8 +4,20 @@ using System.Text;
 
 namespace LightningReview.ReviewFile.Exceptions
 {
-    public class ReviewFileFormatException : Exception
-    {
-        public ReviewFileFormatException(string message = null,Exception innterException=null) : base(message, innterException) { }
-    }
+	/// <summary>
+	/// ReviewFileで使用する例外クラス
+	/// </summary>
+	public class ReviewFileFormatException : Exception
+	{
+		/// <summary>
+		/// エラーメッセージ、およびこの例外の原因である内部例外への参照を指定して
+		/// ReviewFileFormatExceptionクラスの新しいインスタンスを初期化します
+		/// </summary>
+		/// <param name="message">例外の原因を説明するエラーメッセージ</param>
+		/// <param name="innterException">現在の例外の原因である例外</param>
+		public ReviewFileFormatException(string message = null, Exception innterException = null) 
+			: base(message, innterException)
+		{
+		}
+	}
 }

--- a/src/ReviewFile/IReviewFileReader.cs
+++ b/src/ReviewFile/IReviewFileReader.cs
@@ -19,6 +19,11 @@ namespace LightningReview.ReviewFile
         /// <returns>ロードしたレビューモデル</returns>
         IReview Read(string filepath);
 
+        /// <summary>
+        /// 非同期で指定ファイルのレビューファイルを読み込みます。
+        /// </summary>
+        /// <param name="filepath"></param>
+        /// <returns></returns>
         Task<IReview> ReadAsync(string filepath);
 
         /// <summary>
@@ -29,6 +34,12 @@ namespace LightningReview.ReviewFile
         /// <returns>ロードしたレビューモデル</returns>
         IEnumerable<IReview> ReadFolder(string folderPath, bool readSubFodler = false);
         
+        /// <summary>
+        /// 非同期で指定フォルダのレビューファイルを読み込みます。
+        /// </summary>
+        /// <param name="folderPath"></param>
+        /// <param name="readSubFodler"></param>
+        /// <returns></returns>
         Task<IEnumerable<IReview>> ReadFolderAsync(string folderPath, bool readSubFodler = false);
 
         /// <summary>
@@ -38,6 +49,11 @@ namespace LightningReview.ReviewFile
         /// <returns>ロードしたレビューモデル</returns>
         IReview Read(Stream reviewFileStream);
 
+        /// <summary>
+        /// 非同期でレビューファイルのストリームを読み込みます。
+        /// </summary>
+        /// <param name="reviewFileStream"></param>
+        /// <returns></returns>
         Task<IReview> ReadAsync(Stream reviewFileStream);
     }
 }

--- a/src/ReviewFile/IReviewFileReader.cs
+++ b/src/ReviewFile/IReviewFileReader.cs
@@ -7,10 +7,10 @@ using System.Threading.Tasks;
 
 namespace LightningReview.ReviewFile
 {
-	/// <summary>
-	/// レビューファイルのリーダーのインタフェース
-	/// </summary>
-	public interface IReviewFileReader
+    /// <summary>
+    /// レビューファイルのリーダーのインタフェース
+    /// </summary>
+    public interface IReviewFileReader
     {
         /// <summary>
         /// 指定ファイルのレビューファイルを読み込みます。

--- a/src/ReviewFile/Models/IDocument.cs
+++ b/src/ReviewFile/Models/IDocument.cs
@@ -9,36 +9,36 @@ namespace LightningReview.ReviewFile.Models
     /// </summary>
     public interface IDocument
     {
-	    #region 公開プロパティ
+        #region 公開プロパティ
 
-	    /// <summary>
-	    /// グローバルID
-	    /// </summary>
+        /// <summary>
+        /// グローバルID
+        /// </summary>
         string GID { get; set; }
 
-	    /// <summary>
-	    /// ローカルID
-	    /// </summary>
+        /// <summary>
+        /// ローカルID
+        /// </summary>
         string LID { get; set; }
 
-	    /// <summary>
-	    /// ドキュメント名
-	    /// </summary>
+        /// <summary>
+        /// ドキュメント名
+        /// </summary>
         string Name { get; set; }
 
-	    /// <summary>
-	    /// ドキュメントの絶対パス
-	    /// </summary>
-	    string AbsolutePath { get; set; }
+        /// <summary>
+        /// ドキュメントの絶対パス
+        /// </summary>
+        string AbsolutePath { get; set; }
 
-	    /// <summary>
-	    /// 関連づいているアプリケーション
-	    /// </summary>
-	    string ApplicationType { get; set; }
+        /// <summary>
+        /// 関連づいているアプリケーション
+        /// </summary>
+        string ApplicationType { get; set; }
 
-	    /// <summary>
-	    /// このドキュメントに関連づく指摘の一覧
-	    /// </summary>
+        /// <summary>
+        /// このドキュメントに関連づく指摘の一覧
+        /// </summary>
         //IEnumerable<IIssue> AllIssues { get; }
 
         /// <summary>

--- a/src/ReviewFile/Models/IIssue.cs
+++ b/src/ReviewFile/Models/IIssue.cs
@@ -9,7 +9,7 @@ namespace LightningReview.ReviewFile.Models
     /// </summary>
     public interface IIssue
     {
-	    #region 公開プロパティ
+        #region 公開プロパティ
 
         /// <summary>
         /// グローバルID
@@ -125,7 +125,7 @@ namespace LightningReview.ReviewFile.Models
         /// 期日
         /// </summary>
         DateTime? DueDate { get; }
-		
+        
         /// <summary>
         /// 修正日
         /// </summary>

--- a/src/ReviewFile/Models/IOutlineNode.cs
+++ b/src/ReviewFile/Models/IOutlineNode.cs
@@ -9,7 +9,7 @@ namespace LightningReview.ReviewFile.Models
     /// </summary>
     public interface IOutlineNode
     {
-	    #region 公開プロパティ
+        #region 公開プロパティ
         
         /// <summary>
         /// グローバルID

--- a/src/ReviewFile/Models/IReview.cs
+++ b/src/ReviewFile/Models/IReview.cs
@@ -9,7 +9,7 @@ namespace LightningReview.ReviewFile.Models
     /// </summary>
     public interface IReview
     {
-	    #region 公開プロパティ
+        #region 公開プロパティ
 
         /// <summary>
         /// グローバルID
@@ -51,7 +51,7 @@ namespace LightningReview.ReviewFile.Models
         /// </summary>
         DateTime? LastUpdatedDateTime { get; }
 
-	    #region 基本設定タブ
+        #region 基本設定タブ
 
         /// <summary>
         /// レビュー名

--- a/src/ReviewFile/Models/IReview.cs
+++ b/src/ReviewFile/Models/IReview.cs
@@ -51,7 +51,7 @@ namespace LightningReview.ReviewFile.Models
         /// </summary>
         DateTime? LastUpdatedDateTime { get; }
 
-        #region 基本設定タブ
+        #region 基本設定
 
         /// <summary>
         /// レビュー名
@@ -85,7 +85,7 @@ namespace LightningReview.ReviewFile.Models
 
         #endregion
 
-        #region 予実タブ
+        #region 予実
 
         /// <summary>
         /// 計画実施日

--- a/src/ReviewFile/Models/IReviewFile.cs
+++ b/src/ReviewFile/Models/IReviewFile.cs
@@ -9,7 +9,7 @@ namespace LightningReview.ReviewFile.Models
     /// </summary>
     public interface IReviewFile
     {
-	    #region 公開プロパティ
+        #region 公開プロパティ
 
         /// <summary>
         /// スキーマバージョン値

--- a/src/ReviewFile/Models/V10/Document.cs
+++ b/src/ReviewFile/Models/V10/Document.cs
@@ -8,7 +8,7 @@ namespace LightningReview.ReviewFile.Models.V10
     [XmlRoot]
     public class Document : IDocument
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlAttribute]
         public string GlobalID { get; set; }

--- a/src/ReviewFile/Models/V10/Document.cs
+++ b/src/ReviewFile/Models/V10/Document.cs
@@ -5,6 +5,9 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V10
 {
+    /// <summary>
+    /// ドキュメント
+    /// </summary>
     [XmlRoot]
     public class Document : IDocument
     {
@@ -50,6 +53,9 @@ namespace LightningReview.ReviewFile.Models.V10
         [XmlElement]
         public string ApplicationType { get; set; }
         
+        /// <summary>
+        /// アウトラインツリー
+        /// </summary>
         //[XmlArray]
         //[XmlArrayItem("OutlineTree")]
         //public List<OutlineNode> OutlineTree { get; set; }

--- a/src/ReviewFile/Models/V10/Document.cs
+++ b/src/ReviewFile/Models/V10/Document.cs
@@ -10,20 +10,43 @@ namespace LightningReview.ReviewFile.Models.V10
     {
         #region プロパティ
 
+        /// <summary>
+        /// グローバルID（V10定義）
+        /// </summary>
         [XmlAttribute]
         public string GlobalID { get; set; }
+
+        /// <summary>
+        /// グローバルID
+        /// </summary>
         public string GID { get => GlobalID; set => GlobalID = value; }
 
+        /// <summary>
+        /// ローカルID（V10定義）
+        /// </summary>
         [XmlAttribute]
         public string ID { get; set; }
+
+        /// <summary>
+        /// ローカルID
+        /// </summary>
         public string LID { get => ID; set => ID = value; }
 
+        /// <summary>
+        /// ドキュメント名
+        /// </summary>
         [XmlAttribute]
         public string Name { get; set; }
 
+        /// <summary>
+        /// ドキュメントの絶対パス
+        /// </summary>
         [XmlElement]
         public string AbsolutePath { get; set; }
 
+        /// <summary>
+        /// 関連づいているアプリケーション
+        /// </summary>
         [XmlElement]
         public string ApplicationType { get; set; }
         

--- a/src/ReviewFile/Models/V10/Issue.cs
+++ b/src/ReviewFile/Models/V10/Issue.cs
@@ -7,55 +7,111 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V10
 {
+	/// <summary>
+	/// 指摘
+	/// </summary>
     [XmlRoot]
     public class Issue : IIssue
     {
         #region プロパティ
         
+        /// <summary>
+        /// グローバルID（V10定義）
+        /// </summary>
         [XmlAttribute]
         public string GlobalID { get; set; }
+
+        /// <summary>
+        /// グローバルID
+        /// </summary>
         public string GID { get => GlobalID; set => GlobalID = value; }
 
+        /// <summary>
+        /// ローカルID（V10定義）
+        /// </summary>
         [XmlAttribute]
         public string ID { get; set; }
+
+        /// <summary>
+        /// ローカルID
+        /// </summary>
         public string LID { get=>ID; set=>ID=value; }
 
+        /// <summary>
+        /// タイプ
+        /// </summary>
         [XmlElement]
         public string Type { get; set; }
 
+        /// <summary>
+        /// 修正方針
+        /// </summary>
         [XmlElement]
         public string CorrectionPolicy { get; set; }
 
+        /// <summary>
+        /// 分類
+        /// </summary>
         [XmlElement]
         public string Category { get; set; }
 
+        /// <summary>
+        /// 説明
+        /// </summary>
         [XmlElement]
         public string Description { get; set; }
 
+        /// <summary>
+        /// 指摘理由
+        /// </summary>
         [XmlElement]
         public string Reason { get; set; }
 
+        /// <summary>
+        /// 差し戻し理由
+        /// </summary>
         [XmlElement]
         public string SendingBackReason { get; set; }
 
+        /// <summary>
+        /// 指摘のステータス
+        /// </summary>
         [XmlElement]
         public string Status { get; set; }
 
+        /// <summary>
+        /// 現在差戻し中かどうか
+        /// </summary>
         [XmlElement]
         public string IsSendingBack { get; set; }
 
+        /// <summary>
+        /// 過去に一度でも差し戻しがあったか
+        /// </summary>
         [XmlElement]
         public string HasBeenSentBack { get; set; }
         
+        /// <summary>
+        /// 検出工程
+        /// </summary>
         [XmlElement]
         public string DetectionActivity { get; set; }
 
+        /// <summary>
+        /// 原因工程
+        /// </summary>
         [XmlElement]
         public string InjectionActivity { get; set; }
 
+        /// <summary>
+        /// 優先度
+        /// </summary>
         [XmlElement]
         public string Priority { get; set; }
 
+        /// <summary>
+        /// 重大度
+        /// </summary>
         [XmlElement]
         public string Importance { get; set; }
 
@@ -81,72 +137,151 @@ namespace LightningReview.ReviewFile.Models.V10
             }
         }
 
+        /// <summary>
+        /// アウトラインノードのパス
+        /// </summary>
         [XmlElement]
         public string OutlinePath { get; set; }
 
+        /// <summary>
+        /// 報告者
+        /// </summary>
         [XmlElement]
         public string ReportedBy { get; set; }
 
+        /// <summary>
+        /// 報告日の文字列
+        /// </summary>
         [XmlElement("DateReported")]
         public string DateReportedString { get; set; }
+
+        /// <summary>
+        /// 報告日
+        /// </summary>
         public DateTime? DateReported => string.IsNullOrEmpty(DateReportedString) ? (DateTime?) null : DateTime.Parse(DateReportedString);
 
+        /// <summary>
+        /// 対策要否
+        /// </summary>
         [XmlElement]
         public string NeedToFix { get; set; }
 
+        /// <summary>
+        /// 修正者
+        /// </summary>
         [XmlElement]
         public string AssignedTo { get; set; }
 
+        /// <summary>
+        /// 期日の文字列
+        /// </summary>
         [XmlElement("DueDate")]
         public string DueDateString { get; set; }
+
+        /// <summary>
+        /// 期日
+        /// </summary>
         public DateTime? DueDate =>string.IsNullOrEmpty(DueDateString) ? (DateTime?)null : DateTime.Parse(DueDateString);
 
+        /// <summary>
+        /// 修正日の文字列
+        /// </summary>
         [XmlElement("DateFixed")]
         public string DateFixedString { get; set; }
+
+        /// <summary>
+        /// 修正日
+        /// </summary>
         public DateTime? DateFixed => string.IsNullOrEmpty(DateFixedString) ? (DateTime?) null : DateTime.Parse(DateFixedString);
-  
+
+        /// <summary>
+        /// 対策
+        /// </summary>
         [XmlElement]
         public string Resolution { get; set; }
 
+        /// <summary>
+        /// 確認者
+        /// </summary>
         [XmlElement]
         public string ConfirmedBy { get; set; }
 
+        /// <summary>
+        /// 確認日の文字列
+        /// </summary>
         [XmlElement("DateConfirmed")]
         public string DateConfirmedString { get; set; }
+
+        /// <summary>
+        /// 確認日
+        /// </summary>
         public DateTime? DateConfirmed => string.IsNullOrEmpty(DateConfirmedString) ? (DateTime?) null : DateTime.Parse(DateConfirmedString);
 
+        /// <summary>
+        /// コメント
+        /// </summary>
         [XmlElement]
         public string Comment { get; set; }
 
         #region カスタムフィールド
 
+        /// <summary>
+        /// カスタムテキスト1
+        /// </summary>
         [XmlElement]
         public string CustomText1 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト2
+        /// </summary>
         [XmlElement]
         public string CustomText2 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト3
+        /// </summary>
         [XmlElement]
         public string CustomText3 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト4
+        /// </summary>
         [XmlElement]
         public string CustomText4 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト5
+        /// </summary>
         [XmlElement]
         public string CustomText5 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト6
+        /// </summary>
         [XmlElement]
         public string CustomText6 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト7
+        /// </summary>
         [XmlElement]
         public string CustomText7 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト8
+        /// </summary>
         [XmlElement]
         public string CustomText8 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト9
+        /// </summary>
         [XmlElement]
         public string CustomText9 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト10
+        /// </summary>
         [XmlElement]
         public string CustomText10 { get; set; }
 

--- a/src/ReviewFile/Models/V10/Issue.cs
+++ b/src/ReviewFile/Models/V10/Issue.cs
@@ -10,9 +10,9 @@ namespace LightningReview.ReviewFile.Models.V10
     [XmlRoot]
     public class Issue : IIssue
     {
-	    #region プロパティ
+        #region プロパティ
         
-	    [XmlAttribute]
+        [XmlAttribute]
         public string GlobalID { get; set; }
         public string GID { get => GlobalID; set => GlobalID = value; }
 
@@ -63,22 +63,22 @@ namespace LightningReview.ReviewFile.Models.V10
         /// 関連付けられているアウトラインノードの名前
         /// </summary>
         public string OutlineName {
-	        get
-	        {
-		        // アウトラインパスの末尾のアウトライン名を取得
-		        return OutlinePath.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).Last();
-	        }
+            get
+            {
+                // アウトラインパスの末尾のアウトライン名を取得
+                return OutlinePath.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).Last();
+            }
         }
 
         /// <summary>
         /// ルートレベルのアウトラインノードの名前
         /// </summary>
         public string RootOutlineName {
-	        get
-	        {
-		        // アウトラインパスの先頭のアウトライン名を取得
-		        return OutlinePath.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).First();
-	        }
+            get
+            {
+                // アウトラインパスの先頭のアウトライン名を取得
+                return OutlinePath.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).First();
+            }
         }
 
         [XmlElement]

--- a/src/ReviewFile/Models/V10/OutlineNode.cs
+++ b/src/ReviewFile/Models/V10/OutlineNode.cs
@@ -8,7 +8,7 @@ namespace LightningReview.ReviewFile.Models.V10
     [XmlRoot]
     public class OutlineNode : IOutlineNode
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlAttribute]
         public string GlobalID { get; set; }

--- a/src/ReviewFile/Models/V10/OutlineNode.cs
+++ b/src/ReviewFile/Models/V10/OutlineNode.cs
@@ -5,16 +5,28 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V10
 {
+    /// <summary>
+    /// アウトラインノード
+    /// </summary>
     [XmlRoot]
     public class OutlineNode : IOutlineNode
     {
         #region プロパティ
 
+        /// <summary>
+        /// グローバルID（V10定義）
+        /// </summary>
         [XmlAttribute]
         public string GlobalID { get; set; }
 
+        /// <summary>
+        /// グローバルID
+        /// </summary>
         public string GID { get => GlobalID; set => GlobalID = value; }
 
+        /// <summary>
+        /// ノード名
+        /// </summary>
         [XmlAttribute]
         public string Name { get; set; }
 

--- a/src/ReviewFile/Models/V10/Project.cs
+++ b/src/ReviewFile/Models/V10/Project.cs
@@ -8,7 +8,7 @@ namespace LightningReview.ReviewFile.Models.V10
     [XmlRoot]
     public class Project
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlElement]
         public string Code { get; set; }

--- a/src/ReviewFile/Models/V10/Review.cs
+++ b/src/ReviewFile/Models/V10/Review.cs
@@ -8,7 +8,7 @@ namespace LightningReview.ReviewFile.Models.V10
     [XmlRoot]
     public class Review : IReview
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlAttribute]
         public string GlobalID { get; set; }
@@ -65,8 +65,8 @@ namespace LightningReview.ReviewFile.Models.V10
         /// </summary>
         public string ProjectCode
         {
-	        get => Project.Code;
-	        set => Project.Code = value;
+            get => Project.Code;
+            set => Project.Code = value;
         }
 
         /// <summary>
@@ -74,8 +74,8 @@ namespace LightningReview.ReviewFile.Models.V10
         /// </summary>
         public string ProjectName
         {
-	        get => Project.Name;
-	        set => Project.Name = value;
+            get => Project.Name;
+            set => Project.Name = value;
         }
 
         #endregion
@@ -113,22 +113,22 @@ namespace LightningReview.ReviewFile.Models.V10
         /// </summary>
         public string IssueCountOfActual
         {
-	        get
-	        {
-		        var issueCountOfActualCount = 0;
-		        foreach (var issue in Issues)
-		        {
-			        // 指摘タイプがグッドポイントあるいは対策要否が否でない指摘の件数が実績件数
-			        if ((issue.Type == "グッドポイント") || (issue.NeedToFix == "いいえ"))
-			        {
-				        continue;
-			        }
+            get
+            {
+                var issueCountOfActualCount = 0;
+                foreach (var issue in Issues)
+                {
+                    // 指摘タイプがグッドポイントあるいは対策要否が否でない指摘の件数が実績件数
+                    if ((issue.Type == "グッドポイント") || (issue.NeedToFix == "いいえ"))
+                    {
+                        continue;
+                    }
 
-			        issueCountOfActualCount++;
-		        }
+                    issueCountOfActualCount++;
+                }
 
-		        return issueCountOfActualCount.ToString();
-	        }
+                return issueCountOfActualCount.ToString();
+            }
         }
 
         [XmlArray("Documents")]

--- a/src/ReviewFile/Models/V10/Review.cs
+++ b/src/ReviewFile/Models/V10/Review.cs
@@ -43,7 +43,7 @@ namespace LightningReview.ReviewFile.Models.V10
         /// </summary>
         public IEnumerable<IDocument> Documents => DocumentEneities;
 
-        #region 基本設定タブ
+        #region 基本設定
         
         [XmlElement]
         public string Name { get; set; }
@@ -80,7 +80,7 @@ namespace LightningReview.ReviewFile.Models.V10
 
         #endregion
 
-        #region 予実タブ
+        #region 予実
 
         [XmlElement("PlannedDate")]
         public string PlannedDateString { get; set; }

--- a/src/ReviewFile/Models/V10/Review.cs
+++ b/src/ReviewFile/Models/V10/Review.cs
@@ -10,22 +10,49 @@ namespace LightningReview.ReviewFile.Models.V10
     {
         #region プロパティ
 
+        /// <summary>
+        /// グローバルID（V10定義）
+        /// </summary>
         [XmlAttribute]
         public string GlobalID { get; set; }
+
+        /// <summary>
+        /// グローバルID
+        /// </summary>
         public string GID { get => GlobalID; set => GlobalID = value; }
 
+        /// <summary>
+        /// 作成者
+        /// </summary>
         [XmlElement]
         public string CreatedBy { get; set; }
 
+        /// <summary>
+        /// 最終更新者
+        /// </summary>
         [XmlElement]
         public string LastUpdatedBy { get; set; }
 
+        /// <summary>
+        /// 作成日時の文字列
+        /// </summary>
         [XmlElement("CreatedDateTime")]
         public string CreatedDateTimeString { get; set; }
+
+        /// <summary>
+        /// 作成日時
+        /// </summary>
         public DateTime? CreatedDateTime => string.IsNullOrEmpty(CreatedDateTimeString) ? (DateTime?) null : DateTime.Parse(CreatedDateTimeString);
 
+        /// <summary>
+        /// 最終更新日時
+        /// </summary>
         [XmlElement("LastUpdatedDateTime")]
         public string LastUpdatedDateTimeString { get; set; }
+
+        /// <summary>
+        /// 最終更新日時の文字列
+        /// </summary>
         public DateTime? LastUpdatedDateTime => string.IsNullOrEmpty(LastUpdatedDateTimeString) ? (DateTime?) null : DateTime.Parse(LastUpdatedDateTimeString);
 
         /// <summary>

--- a/src/ReviewFile/Models/V10/ReviewFile.cs
+++ b/src/ReviewFile/Models/V10/ReviewFile.cs
@@ -5,14 +5,23 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V10
 {
+    /// <summary>
+    /// レビューファイル
+    /// </summary>
     [XmlRoot]
     public class ReviewFile : IReviewFile
     {
         #region プロパティ
         
+        /// <summary>
+        /// スキーマバージョン値
+        /// </summary>
         [XmlElement]
         public string SchemaVersion { get; set; }
 
+        /// <summary>
+        /// レビュー
+        /// </summary>
         [XmlElement]
         public Review Review { get; set; }
 

--- a/src/ReviewFile/Models/V10/ReviewFile.cs
+++ b/src/ReviewFile/Models/V10/ReviewFile.cs
@@ -8,7 +8,7 @@ namespace LightningReview.ReviewFile.Models.V10
     [XmlRoot]
     public class ReviewFile : IReviewFile
     {
-	    #region プロパティ
+        #region プロパティ
         
         [XmlElement]
         public string SchemaVersion { get; set; }

--- a/src/ReviewFile/Models/V18/Defenitions/Defenition.cs
+++ b/src/ReviewFile/Models/V18/Defenitions/Defenition.cs
@@ -5,13 +5,21 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18.Defenitions
 {
-
+    /// <summary>
+    /// 定義
+    /// </summary>
     [XmlRoot]
     public class Defenition : EntityBase
     {
+        /// <summary>
+        /// 未対応の要素
+        /// </summary>
         [XmlElement]
         public string Code { get; set; }
 
+        /// <summary>
+        /// 未対応の要素
+        /// </summary>
         [XmlElement]
         public string Name { get; set; }
     }

--- a/src/ReviewFile/Models/V18/Document.cs
+++ b/src/ReviewFile/Models/V18/Document.cs
@@ -6,17 +6,29 @@ using System.Linq;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// ドキュメント
+    /// </summary>
     [XmlRoot]
     public class Document : EntityBase,IDocument
     {
         #region プロパティ
         
+        /// <summary>
+        /// ローカルID
+        /// </summary>
         [XmlElement]
         public string LID { get; set; }
 
+        /// <summary>
+        /// ドキュメント名
+        /// </summary>
         [XmlElement]
         public string Name { get; set; }
 
+        /// <summary>
+        /// ドキュメントの絶対パス
+        /// </summary>
         [XmlElement]
         public string AbsolutePath { get; set; }
 

--- a/src/ReviewFile/Models/V18/Document.cs
+++ b/src/ReviewFile/Models/V18/Document.cs
@@ -9,9 +9,9 @@ namespace LightningReview.ReviewFile.Models.V18
     [XmlRoot]
     public class Document : EntityBase,IDocument
     {
-	    #region プロパティ
+        #region プロパティ
         
-	    [XmlElement]
+        [XmlElement]
         public string LID { get; set; }
 
         [XmlElement]

--- a/src/ReviewFile/Models/V18/Documents.cs
+++ b/src/ReviewFile/Models/V18/Documents.cs
@@ -8,7 +8,7 @@ namespace LightningReview.ReviewFile.Models.V18
     [XmlRoot]
     public class Documents : EntityBase
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlArray("List")]
         [XmlArrayItem("Document")]

--- a/src/ReviewFile/Models/V18/Documents.cs
+++ b/src/ReviewFile/Models/V18/Documents.cs
@@ -5,11 +5,17 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// ドキュメントの一覧
+    /// </summary>
     [XmlRoot]
     public class Documents : EntityBase
     {
         #region プロパティ
 
+        /// <summary>
+        /// ドキュメントの一覧
+        /// </summary>
         [XmlArray("List")]
         [XmlArrayItem("Document")]
         public List<Document> List { get; set; } = new List<Document>();

--- a/src/ReviewFile/Models/V18/EntityBase.cs
+++ b/src/ReviewFile/Models/V18/EntityBase.cs
@@ -5,6 +5,9 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// 各エンティティに共通する基底クラス
+    /// </summary>
     public abstract class EntityBase
     {
         #region 構築
@@ -21,21 +24,44 @@ namespace LightningReview.ReviewFile.Models.V18
 
         #region プロパティ
 
+        /// <summary>
+        /// グローバルID
+        /// </summary>
         [XmlElement]
         public string GID { get; set; } 
 
+        /// <summary>
+        /// 作成者
+        /// </summary>
         [XmlElement]
         public string CreatedBy { get; set; }
 
+        /// <summary>
+        /// 最終更新者
+        /// </summary>
         [XmlElement]
         public string LastUpdatedBy { get; set; }
 
+        /// <summary>
+        /// 作成日時の文字列
+        /// </summary>
         [XmlElement("CreatedDateTime")]
         public string CreatedDateTimeString { get; set; }
+
+        /// <summary>
+        /// 作成日時
+        /// </summary>
         public DateTime? CreatedDateTime => string.IsNullOrEmpty(CreatedDateTimeString) ? (DateTime?) null : DateTime.Parse(CreatedDateTimeString);
 
+        /// <summary>
+        /// 最終更新日時の文字列
+        /// </summary>
         [XmlElement("LastUpdatedDateTime")]
         public string LastUpdatedDateTimeString { get; set; }
+
+        /// <summary>
+        /// 最終更新日時
+        /// </summary>
         public DateTime? LastUpdatedDateTime => string.IsNullOrEmpty(LastUpdatedDateTimeString) ? (DateTime?) null : DateTime.Parse(LastUpdatedDateTimeString);
 
         #endregion

--- a/src/ReviewFile/Models/V18/EntityBase.cs
+++ b/src/ReviewFile/Models/V18/EntityBase.cs
@@ -7,7 +7,7 @@ namespace LightningReview.ReviewFile.Models.V18
 {
     public abstract class EntityBase
     {
-	    #region 構築
+        #region 構築
 
         /// <summary>
         /// コンストラクタ

--- a/src/ReviewFile/Models/V18/Issue.cs
+++ b/src/ReviewFile/Models/V18/Issue.cs
@@ -11,9 +11,9 @@ namespace LightningReview.ReviewFile.Models.V18
     [XmlRoot]
     public class Issue : EntityBase,IIssue
     {
-	    #region プロパティ
+        #region プロパティ
 
-	    [XmlElement]
+        [XmlElement]
         public string LID { get; set; }
 
         [XmlElement]
@@ -59,22 +59,22 @@ namespace LightningReview.ReviewFile.Models.V18
         /// 関連付けられているアウトラインノードの名前
         /// </summary>
         public string OutlineName {
-	        get
-	        {
-		        // アウトラインパスの末尾のアウトライン名を取得
-		        return OutlinePath.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).Last();
-	        }
+            get
+            {
+                // アウトラインパスの末尾のアウトライン名を取得
+                return OutlinePath.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).Last();
+            }
         }
 
         /// <summary>
         /// ルートレベルのアウトラインノードの名前
         /// </summary>
         public string RootOutlineName {
-	        get
-	        {
-		        // アウトラインパスの先頭のアウトライン名を取得
-		        return OutlinePath.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).First();
-	        }
+            get
+            {
+                // アウトラインパスの先頭のアウトライン名を取得
+                return OutlinePath.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).First();
+            }
         }
 
         [XmlElement]

--- a/src/ReviewFile/Models/V18/Issue.cs
+++ b/src/ReviewFile/Models/V18/Issue.cs
@@ -8,50 +8,95 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// 指摘
+    /// </summary>
     [XmlRoot]
     public class Issue : EntityBase,IIssue
     {
         #region プロパティ
 
+        /// <summary>
+        /// ローカルID
+        /// </summary>
         [XmlElement]
         public string LID { get; set; }
 
+        /// <summary>
+        /// タイプ
+        /// </summary>
         [XmlElement]
         public string Type { get; set; }
 
+        /// <summary>
+        /// 修正方針
+        /// </summary>
         [XmlElement]
         public string CorrectionPolicy { get; set; }
 
+        /// <summary>
+        /// 分類
+        /// </summary>
         [XmlElement]
         public string Category { get; set; }
 
+        /// <summary>
+        /// 説明
+        /// </summary>
         [XmlElement]
         public string Description { get; set; }
 
+        /// <summary>
+        /// 指摘理由
+        /// </summary>
         [XmlElement]
         public string Reason { get; set; }
 
+        /// <summary>
+        /// 差し戻し理由
+        /// </summary>
         [XmlElement]
         public string SendingBackReason { get; set; }
 
+        /// <summary>
+        /// 指摘のステータス
+        /// </summary>
         [XmlElement]
         public string Status { get; set; }
 
+        /// <summary>
+        /// 現在差戻し中かどうか
+        /// </summary>
         [XmlElement]
         public string IsSendingBack { get; set; }
 
+        /// <summary>
+        /// 過去に一度でも差し戻しがあったか
+        /// </summary>
         [XmlElement]
         public string HasBeenSentBack { get; set; }
 
+        /// <summary>
+        /// 検出工程
+        /// </summary>
         [XmlElement]
         public string DetectionActivity { get; set; }
 
+        /// <summary>
+        /// 原因工程
+        /// </summary>
         [XmlElement]
         public string InjectionActivity { get; set; }
 
+        /// <summary>
+        /// 優先度
+        /// </summary>
         [XmlElement]
         public string Priority { get; set; }
 
+        /// <summary>
+        /// 重大度
+        /// </summary>
         [XmlElement]
         public string Importance { get; set; }
 
@@ -77,72 +122,151 @@ namespace LightningReview.ReviewFile.Models.V18
             }
         }
 
+        /// <summary>
+        /// アウトラインノードのパス
+        /// </summary>
         [XmlElement]
         public string OutlinePath { get; set; }
 
+        /// <summary>
+        /// 報告者
+        /// </summary>
         [XmlElement]
         public string ReportedBy { get; set; }
 
+        /// <summary>
+        /// 報告日の文字列
+        /// </summary>
         [XmlElement("DateReported")]
         public string DateReportedString { get; set; }
+
+        /// <summary>
+        /// 報告日
+        /// </summary>
         public DateTime? DateReported => string.IsNullOrEmpty(DateReportedString) ? (DateTime?) null : DateTime.Parse(DateReportedString);
 
+        /// <summary>
+        /// 対策要否
+        /// </summary>
         [XmlElement]
         public string NeedToFix { get; set; }
 
+        /// <summary>
+        /// 修正者
+        /// </summary>
         [XmlElement]
         public string AssignedTo { get; set; }
 
+        /// <summary>
+        /// 期日の文字列
+        /// </summary>
         [XmlElement("DueDate")]
         public string DueDateString { get; set; }
+
+        /// <summary>
+        /// 期日
+        /// </summary>
         public DateTime? DueDate =>string.IsNullOrEmpty(DueDateString) ? (DateTime?)null : DateTime.Parse(DueDateString);
 
+        /// <summary>
+        /// 修正日の文字列
+        /// </summary>
         [XmlElement("DateFixed")]
         public string DateFixedString { get; set; }
+
+        /// <summary>
+        /// 修正日
+        /// </summary>
         public DateTime? DateFixed => string.IsNullOrEmpty(DateFixedString) ? (DateTime?) null : DateTime.Parse(DateFixedString);
-  
+
+        /// <summary>
+        /// 対策
+        /// </summary>
         [XmlElement]
         public string Resolution { get; set; }
 
+        /// <summary>
+        /// 確認者
+        /// </summary>
         [XmlElement]
         public string ConfirmedBy { get; set; }
 
+        /// <summary>
+        /// 確認日の文字列
+        /// </summary>
         [XmlElement("DateConfirmed")]
         public string DateConfirmedString { get; set; }
+
+        /// <summary>
+        /// 確認日
+        /// </summary>
         public DateTime? DateConfirmed => string.IsNullOrEmpty(DateConfirmedString) ? (DateTime?) null : DateTime.Parse(DateConfirmedString);
         
+        /// <summary>
+        /// コメント
+        /// </summary>
         [XmlElement]
         public string Comment { get; set; }
 
         #region カスタムフィールド
 
+        /// <summary>
+        /// カスタムテキスト1
+        /// </summary>
         [XmlElement]
         public string CustomText1 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト2
+        /// </summary>
         [XmlElement]
         public string CustomText2 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト3
+        /// </summary>
         [XmlElement]
         public string CustomText3 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト4
+        /// </summary>
         [XmlElement]
         public string CustomText4 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト5
+        /// </summary>
         [XmlElement]
         public string CustomText5 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト6
+        /// </summary>
         [XmlElement]
         public string CustomText6 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト7
+        /// </summary>
         [XmlElement]
         public string CustomText7 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト8
+        /// </summary>
         [XmlElement]
         public string CustomText8 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト9
+        /// </summary>
         [XmlElement]
         public string CustomText9 { get; set; }
 
+        /// <summary>
+        /// カスタムテキスト10
+        /// </summary>
         [XmlElement]
         public string CustomText10 { get; set; }
 

--- a/src/ReviewFile/Models/V18/Issues.cs
+++ b/src/ReviewFile/Models/V18/Issues.cs
@@ -5,11 +5,17 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// 指摘の一覧
+    /// </summary>
     [XmlRoot]
     public class Issues : EntityBase
     {
         #region プロパティ
 
+        /// <summary>
+        /// 指摘の一覧
+        /// </summary>
         [XmlArray("List")]
         [XmlArrayItem("Issue")]
         public List<Issue> List { get; set; }  = new List<Issue>();

--- a/src/ReviewFile/Models/V18/Issues.cs
+++ b/src/ReviewFile/Models/V18/Issues.cs
@@ -8,7 +8,7 @@ namespace LightningReview.ReviewFile.Models.V18
     [XmlRoot]
     public class Issues : EntityBase
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlArray("List")]
         [XmlArrayItem("Issue")]

--- a/src/ReviewFile/Models/V18/OutlineNode.cs
+++ b/src/ReviewFile/Models/V18/OutlineNode.cs
@@ -6,17 +6,29 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// アウトラインノード
+    /// </summary>
     [XmlRoot]
     public class OutlineNode : EntityBase,IOutlineNode
     {
         #region プロパティ
 
+        /// <summary>
+        /// ノード名
+        /// </summary>
         [XmlElement]
         public string Name { get; set; }
 
+        /// <summary>
+        /// このアウトラインに関連づく指摘の一覧
+        /// </summary>
         [XmlElement]
         public Issues Issues { get; set; } = new Issues();
 
+        /// <summary>
+        /// 子ノードの一覧
+        /// </summary>
         [XmlArray("Children")]
         [XmlArrayItem("OutlineNode")]
         public List<OutlineNode> ChildNodes{ get; set; } = new List<OutlineNode>();

--- a/src/ReviewFile/Models/V18/OutlineNode.cs
+++ b/src/ReviewFile/Models/V18/OutlineNode.cs
@@ -9,7 +9,7 @@ namespace LightningReview.ReviewFile.Models.V18
     [XmlRoot]
     public class OutlineNode : EntityBase,IOutlineNode
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlElement]
         public string Name { get; set; }

--- a/src/ReviewFile/Models/V18/OutlineTree.cs
+++ b/src/ReviewFile/Models/V18/OutlineTree.cs
@@ -5,11 +5,17 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// アウトラインツリー
+    /// </summary>
     [XmlRoot]
     public class OutlineTree : EntityBase
     {
         #region プロパティ
 
+        /// <summary>
+        /// 仮想で保持するルートノード
+        /// </summary>
         [XmlElement]
         public OutlineNode VirtualRoot { get; set; } = new OutlineNode();
 

--- a/src/ReviewFile/Models/V18/OutlineTree.cs
+++ b/src/ReviewFile/Models/V18/OutlineTree.cs
@@ -8,9 +8,9 @@ namespace LightningReview.ReviewFile.Models.V18
     [XmlRoot]
     public class OutlineTree : EntityBase
     {
-	    #region プロパティ
+        #region プロパティ
 
-	    [XmlElement]
+        [XmlElement]
         public OutlineNode VirtualRoot { get; set; } = new OutlineNode();
 
         #endregion

--- a/src/ReviewFile/Models/V18/Project.cs
+++ b/src/ReviewFile/Models/V18/Project.cs
@@ -9,7 +9,7 @@ namespace LightningReview.ReviewFile.Models.V18
     [XmlRoot]
     public class Project : EntityBase
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlElement]
         public string Code { get; set; }

--- a/src/ReviewFile/Models/V18/Project.cs
+++ b/src/ReviewFile/Models/V18/Project.cs
@@ -5,15 +5,23 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
-
+    /// <summary>
+    /// プロジェクト
+    /// </summary>
     [XmlRoot]
     public class Project : EntityBase
     {
         #region プロパティ
 
+        /// <summary>
+        /// プロジェクトコード
+        /// </summary>
         [XmlElement]
         public string Code { get; set; }
 
+        /// <summary>
+        /// プロジェクト名
+        /// </summary>
         [XmlElement]
         public string Name { get; set; }
 

--- a/src/ReviewFile/Models/V18/Review.cs
+++ b/src/ReviewFile/Models/V18/Review.cs
@@ -22,18 +22,18 @@ namespace LightningReview.ReviewFile.Models.V18
         /// </summary>
         public IEnumerable<IIssue> Issues
         {
-	        get
-	        {
-		        var issues = new List<IIssue>();
+            get
+            {
+                var issues = new List<IIssue>();
 
-		        // 各ドキュメントの指摘
-		        foreach (var doc in Documents.List)
-		        {
-			        issues.AddRange(doc.AllIssues);
-		        }
+                // 各ドキュメントの指摘
+                foreach (var doc in Documents.List)
+                {
+                    issues.AddRange(doc.AllIssues);
+                }
 
-		        return issues.ToList();
-	        }
+                return issues.ToList();
+            }
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace LightningReview.ReviewFile.Models.V18
         /// </summary>
         public string ProjectCode
         {
-	        get => Project.Code;
-	        set => Project.Code = value;
+            get => Project.Code;
+            set => Project.Code = value;
         }
 
         /// <summary>
@@ -78,8 +78,8 @@ namespace LightningReview.ReviewFile.Models.V18
         /// </summary>
         public string ProjectName
         {
-	        get => Project.Name;
-	        set => Project.Name = value;
+            get => Project.Name;
+            set => Project.Name = value;
         }
 
         #endregion
@@ -117,26 +117,26 @@ namespace LightningReview.ReviewFile.Models.V18
         /// </summary>
         public string IssueCountOfActual
         {
-	        get
-	        {
-		        var issueCountOfActualCount = 0;
-		        foreach (var issue in Issues)
-		        {
+            get
+            {
+                var issueCountOfActualCount = 0;
+                foreach (var issue in Issues)
+                {
                     // 指摘タイプがグッドポイントあるいは対策要否が否でない指摘の件数が実績件数
-			        if ((issue.Type == "グッドポイント") || (issue.NeedToFix == "いいえ"))
-			        {
+                    if ((issue.Type == "グッドポイント") || (issue.NeedToFix == "いいえ"))
+                    {
                         continue;
-			        }
+                    }
 
-			        issueCountOfActualCount++;
-		        }
+                    issueCountOfActualCount++;
+                }
 
-		        return issueCountOfActualCount.ToString();
-	        }
+                return issueCountOfActualCount.ToString();
+            }
         }
 
         #endregion
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/src/ReviewFile/Models/V18/Review.cs
+++ b/src/ReviewFile/Models/V18/Review.cs
@@ -41,7 +41,7 @@ namespace LightningReview.ReviewFile.Models.V18
         /// </summary>
         IEnumerable<IDocument> IReview.Documents => Documents.List.OfType<IDocument>();
 
-        #region 基本設定タブ
+        #region 基本設定
         
         [XmlElement]
         public string Name { get; set; }
@@ -84,7 +84,7 @@ namespace LightningReview.ReviewFile.Models.V18
 
         #endregion
 
-        #region 予実タブ
+        #region 予実
 
         [XmlElement("PlannedDate")]
         public string PlannedDateString { get; set; }

--- a/src/ReviewFile/Models/V18/Review.cs
+++ b/src/ReviewFile/Models/V18/Review.cs
@@ -7,6 +7,9 @@ using LightningReview.ReviewFile.Models.V18.Defenitions;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// レビュー
+    /// </summary>
     [XmlRoot]
     public class Review : EntityBase, IReview
     {
@@ -43,19 +46,33 @@ namespace LightningReview.ReviewFile.Models.V18
 
         #region 基本設定
         
+        /// <summary>
+        /// レビュー名
+        /// </summary>
         [XmlElement]
         public string Name { get; set; }
 
+        /// <summary>
+        /// 目的
+        /// </summary>
         [XmlElement]
         public string Goal { get; set; }
 
+        /// <summary>
+        /// 終了条件
+        /// </summary>
         [XmlElement]
         public string EndCondition { get; set; }
         
+        /// <summary>
+        /// 場所
+        /// </summary>
         [XmlElement]
         public string Place { get; set; }
 
-        
+        /// <summary>
+        /// このレビューファイルに関連づくドキュメントの一覧
+        /// </summary>
         [XmlElement]
         public Documents Documents { get; set; }
 
@@ -86,29 +103,61 @@ namespace LightningReview.ReviewFile.Models.V18
 
         #region 予実
 
+        /// <summary>
+        /// 計画実施日の文字列
+        /// </summary>
         [XmlElement("PlannedDate")]
         public string PlannedDateString { get; set; }
+
+        /// <summary>
+        /// 計画実施日
+        /// </summary>
         public DateTime? PlannedDate => string.IsNullOrEmpty(PlannedDateString) ? (DateTime?) null : DateTime.Parse(PlannedDateString);
 
+        /// <summary>
+        /// 実績実施日の文字列
+        /// </summary>
         [XmlElement("ActualDate")]
         public string ActualDateString { get; set; }
+
+        /// <summary>
+        /// 実績実施日
+        /// </summary>
         public DateTime? ActualDate => string.IsNullOrEmpty(ActualDateString) ? (DateTime?) null : DateTime.Parse(ActualDateString);
 
+        /// <summary>
+        /// 計画時間（分単位）
+        /// </summary>
         [XmlElement]
         public string PlannedTime { get; set; }
 
+        /// <summary>
+        /// 実績時間(分単位)
+        /// </summary>
         [XmlElement]
         public string ActualTime { get; set; }
 
+        /// <summary>
+        /// 成果物単位
+        /// </summary>
         [XmlElement]
         public string Unit { get; set; }
 
+        /// <summary>
+        /// 予定規模
+        /// </summary>
         [XmlElement]
         public string PlannedScale { get; set; }
 
+        /// <summary>
+        /// 実績規模
+        /// </summary>
         [XmlElement]
         public string ActualScale { get; set; }
 
+        /// <summary>
+        /// 目標件数
+        /// </summary>
         [XmlElement]
         public string IssueCountOfGoal { get; set; }
 

--- a/src/ReviewFile/Models/V18/ReviewFile.cs
+++ b/src/ReviewFile/Models/V18/ReviewFile.cs
@@ -5,14 +5,23 @@ using System.Xml.Serialization;
 
 namespace LightningReview.ReviewFile.Models.V18
 {
+    /// <summary>
+    /// レビューファイル
+    /// </summary>
     [XmlRoot]
     public class ReviewFile : IReviewFile
     {
         #region プロパティ
 
+        /// <summary>
+        /// スキーマバージョン値
+        /// </summary>
         [XmlElement]
         public string SchemaVersion { get; set; }
 
+        /// <summary>
+        /// レビュー
+        /// </summary>
         [XmlElement]
         public Review Review { get; set; }
 

--- a/src/ReviewFile/Models/V18/ReviewFile.cs
+++ b/src/ReviewFile/Models/V18/ReviewFile.cs
@@ -8,7 +8,7 @@ namespace LightningReview.ReviewFile.Models.V18
     [XmlRoot]
     public class ReviewFile : IReviewFile
     {
-	    #region プロパティ
+        #region プロパティ
 
         [XmlElement]
         public string SchemaVersion { get; set; }

--- a/src/ReviewFile/ReviewFile.csproj
+++ b/src/ReviewFile/ReviewFile.csproj
@@ -11,16 +11,16 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>LightningReview.ReviewFile</PackageId>
-    <PackageVersion>0.8.6</PackageVersion>
-    <Version>0.8.6</Version>
+    <PackageVersion>0.8.7</PackageVersion>
+    <Version>0.8.7</Version>
     <Authors>DENSO CREATE CO., LTD</Authors>
     <Company>DENSO CREATE CO., LTD</Company>
     <RepositoryUrl>https://github.com/denso-create/LightningReview-ReviewFile</RepositoryUrl>
     <RepositoryType>github</RepositoryType>
     <PackageProjectUrl>https://github.com/denso-create/LightningReview-ReviewFile</PackageProjectUrl>
-    <PackageReleaseNotes>Modelのフィールドを拡充</PackageReleaseNotes>
-    <AssemblyVersion>0.8.6.0</AssemblyVersion>
-    <FileVersion>0.8.6.0</FileVersion>
+    <PackageReleaseNotes>ドキュメントおよびコメントの拡充と推敲を行った</PackageReleaseNotes>
+    <AssemblyVersion>0.8.7.0</AssemblyVersion>
+    <FileVersion>0.8.7.0</FileVersion>
   </PropertyGroup>
     
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/ReviewFile/ReviewFileReader.cs
+++ b/src/ReviewFile/ReviewFileReader.cs
@@ -108,13 +108,13 @@ namespace LightningReview.ReviewFile
             }
             catch (Exception ex)
             {
-	            throw new ReviewFileFormatException(ex.Message, ex);
+                throw new ReviewFileFormatException(ex.Message, ex);
             }
         }
 
         public async Task<IReview> ReadAsync(Stream reviewFileStream)
         {
-	        return await Task.Run(() => Read(reviewFileStream));
+            return await Task.Run(() => Read(reviewFileStream));
         }
     }
 }

--- a/src/ReviewFile/ReviewFileReader.cs
+++ b/src/ReviewFile/ReviewFileReader.cs
@@ -41,6 +41,11 @@ namespace LightningReview.ReviewFile
             }
         }
 
+        /// <summary>
+        /// 非同期でファイルからロードします。
+        /// </summary>
+        /// <param name="filePath">レビューファイルのパス</param>
+        /// <returns>ロードしたレビューモデル</returns>
         public async Task<IReview> ReadAsync(string filepath)
         {
             return await Task.Run(() => Read(filepath));
@@ -74,6 +79,12 @@ namespace LightningReview.ReviewFile
             return reviews;
         }
 
+        /// <summary>
+        /// 非同期でフォルダからロードします。
+        /// </summary>
+        /// <param name="folderPath">フォルダのパス</param>
+        /// <param name="includeSubFodler">サブフォルダも対象にするか</param>
+        /// <returns>ロードしたレビューモデル</returns>
         public async Task<IEnumerable<IReview>> ReadFolderAsync(string folderPath, bool readSubFodler = false)
         {
             return await Task.Run(() => ReadFolderAsync(folderPath, readSubFodler));
@@ -112,6 +123,11 @@ namespace LightningReview.ReviewFile
             }
         }
 
+        /// <summary>
+        /// 非同期でストリームからロードします。
+        /// </summary>
+        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
+        /// <returns>ロードしたレビューモデル</returns>
         public async Task<IReview> ReadAsync(Stream reviewFileStream)
         {
             return await Task.Run(() => Read(reviewFileStream));

--- a/src/ReviewFileToJsonCLI/Program.cs
+++ b/src/ReviewFileToJsonCLI/Program.cs
@@ -15,14 +15,17 @@ namespace ReviewFileToJson
         /// </summary>
         class Options
         {
-            [Option('f',"folder",Required =true,HelpText ="対象のレビューファイルが存在しているフォルダを指定します。")]
-            public string FolderPath { get; set; }
+	        [Option('f', "folder", Required = true, HelpText = "対象のレビューファイルが存在しているフォルダを指定します。")]
+	        public string FolderPath { get; set; }
 
-            [Option('o', "output", Required = false, HelpText = "JSONファイルの出力先のパスを指定します。")]
-            public string OutputPath { get; set; }
+	        [Option('o', "output", Required = false, HelpText = "JSONファイルの出力先のパスを指定します。")]
+	        public string OutputPath { get; set; }
 
-            [Option('r', "recursive", Required = false,  HelpText = "サブフォルダも含めてファイルを検索します。" , Default =false)]
-            public bool Recursive { get; set; }
+	        [Option('r', "recursive", Required = false, HelpText = "サブフォルダも含めてファイルを検索します。", Default = false)]
+	        public bool Recursive { get; set; }
+
+	        [Option('u', "unescaped", Required = false, HelpText = "出力JSONファイル内の日本語をUnicodeエスケープしません。", Default = false)]
+	        public bool UnescapedUnicode { get; set; }
         }
 
         /// <summary>
@@ -33,6 +36,7 @@ namespace ReviewFileToJson
         {
 
             #region コマンドライン引数を取得
+
             // 引数を取得
             var parseResult = Parser.Default.ParseArguments<Options>(args);
             if (parseResult.Tag == ParserResultType.NotParsed)
@@ -60,6 +64,9 @@ namespace ReviewFileToJson
             // サブフォルダを含む
             var recursive = parsed.Value.Recursive;
 
+            // Unicodeエスケープを防止
+            var unescapedUnicode = parsed.Value.UnescapedUnicode;
+
             #endregion
 
             #region 処理の実行
@@ -76,7 +83,7 @@ namespace ReviewFileToJson
             Console.WriteLine($"フォルダ{folderPath}のレビューファイルを検索しています。");
 
             // 実行
-            exporter.Export(folderPath, outputPath, recursive);
+            exporter.Export(folderPath, outputPath, recursive, unescapedUnicode);
             stopWatch.Stop();
 
             // 完了メッセージ

--- a/src/ReviewFileToJsonCLI/Program.cs
+++ b/src/ReviewFileToJsonCLI/Program.cs
@@ -10,79 +10,79 @@ namespace ReviewFileToJson
 {
     class Program
     {
-		/// <summary>
-		/// コマンドラインパーサのオプション設定
-		/// </summary>
-		class Options
-		{
-			[Option('f',"folder",Required =true,HelpText ="対象のレビューファイルが存在しているフォルダを指定します。")]
-			public string FolderPath { get; set; }
+        /// <summary>
+        /// コマンドラインパーサのオプション設定
+        /// </summary>
+        class Options
+        {
+            [Option('f',"folder",Required =true,HelpText ="対象のレビューファイルが存在しているフォルダを指定します。")]
+            public string FolderPath { get; set; }
 
-			[Option('o', "output", Required = false, HelpText = "JSONファイルの出力先のパスを指定します。")]
-			public string OutputPath { get; set; }
+            [Option('o', "output", Required = false, HelpText = "JSONファイルの出力先のパスを指定します。")]
+            public string OutputPath { get; set; }
 
-			[Option('r', "recursive", Required = false,  HelpText = "サブフォルダも含めてファイルを検索します。" , Default =false)]
-			public bool Recursive { get; set; }
-		}
+            [Option('r', "recursive", Required = false,  HelpText = "サブフォルダも含めてファイルを検索します。" , Default =false)]
+            public bool Recursive { get; set; }
+        }
 
-		/// <summary>
-		/// メイン
-		/// </summary>
-		/// <param name="args"></param>
-		static void Main(string[] args)
+        /// <summary>
+        /// メイン
+        /// </summary>
+        /// <param name="args"></param>
+        static void Main(string[] args)
         {
 
-			#region コマンドライン引数を取得
-			// 引数を取得
-			var parseResult = Parser.Default.ParseArguments<Options>(args);
-			if (parseResult.Tag == ParserResultType.NotParsed)
-			{
-				Console.WriteLine($"エラー：パラメータの指定に誤りがあります。");
-				return;
-			}  
+            #region コマンドライン引数を取得
+            // 引数を取得
+            var parseResult = Parser.Default.ParseArguments<Options>(args);
+            if (parseResult.Tag == ParserResultType.NotParsed)
+            {
+                Console.WriteLine($"エラー：パラメータの指定に誤りがあります。");
+                return;
+            }  
 
-			var parsed = parseResult as Parsed<Options>;
+            var parsed = parseResult as Parsed<Options>;
 
-			// 対象のフォルダパスおよび出力パスを取得
-			var folderPath = parsed.Value.FolderPath;
-			if (!Directory.Exists(folderPath))
-			{
-				Console.WriteLine($"エラー：指定したフォルダ{folderPath}は存在しません。");
-				return;
-			}
+            // 対象のフォルダパスおよび出力パスを取得
+            var folderPath = parsed.Value.FolderPath;
+            if (!Directory.Exists(folderPath))
+            {
+                Console.WriteLine($"エラー：指定したフォルダ{folderPath}は存在しません。");
+                return;
+            }
 
-			// 出力先のファイルが指定なければ設定する
-			var outputPath = parsed.Value.OutputPath;
-			if ( string.IsNullOrEmpty(outputPath) ) {
-				outputPath = "output.json";
-			}
+            // 出力先のファイルが指定なければ設定する
+            var outputPath = parsed.Value.OutputPath;
+            if ( string.IsNullOrEmpty(outputPath) ) {
+                outputPath = "output.json";
+            }
 
-			// サブフォルダを含む
-			var recursive = parsed.Value.Recursive;
+            // サブフォルダを含む
+            var recursive = parsed.Value.Recursive;
 
             #endregion
 
             #region 処理の実行
 
-			// ストップウォッチを用意しておく
+            // ストップウォッチを用意しておく
             var stopWatch = new Stopwatch();
-			stopWatch.Start();
+            stopWatch.Start();
 
-			// エクスポート処理
-			var exporter = new ReviewFileToJsonExporter();
+            // エクスポート処理
+            var exporter = new ReviewFileToJsonExporter();
 
-			// ロガーを設定しておく
-			exporter.Logger = (message) => Console.WriteLine(message);
-			Console.WriteLine($"フォルダ{folderPath}のレビューファイルを検索しています。");
+            // ロガーを設定しておく
+            exporter.Logger = (message) => Console.WriteLine(message);
+            Console.WriteLine($"フォルダ{folderPath}のレビューファイルを検索しています。");
 
-			// 実行
-			exporter.Export(folderPath, outputPath, recursive);
-			stopWatch.Stop();
+            // 実行
+            exporter.Export(folderPath, outputPath, recursive);
+            stopWatch.Stop();
 
             // 完了メッセージ
             Console.WriteLine($"成功：検索したレビューファイルのJsonデータを{outputPath}に作成しました（処理時間 {stopWatch.ElapsedMilliseconds}ms)。");
 
-			#endregion
-		}
-	}
+            #endregion
+        }
+    }
 }

--- a/src/ReviewFileToJsonService/Models/Issue.cs
+++ b/src/ReviewFileToJsonService/Models/Issue.cs
@@ -11,14 +11,14 @@ namespace ReviewFileToJsonService.Models
     /// </summary>
     public class Issue 
     {
-	    #region 構築
+        #region 構築
 
-	    /// <summary>
-	    /// コンストラクタ
-	    /// </summary>
-	    public Issue()
-	    {
-	    }
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public Issue()
+        {
+        }
 
         /// <summary>
         /// コンストラクタ
@@ -148,7 +148,7 @@ namespace ReviewFileToJsonService.Models
         /// 期日
         /// </summary>
         public DateTime? DueDate { get; set; }
-		
+        
         /// <summary>
         /// 修正日
         /// </summary>

--- a/src/ReviewFileToJsonService/Models/Review.cs
+++ b/src/ReviewFileToJsonService/Models/Review.cs
@@ -51,12 +51,7 @@ namespace ReviewFileToJsonService.Models
         /// レビューファイルの絶対パス
         /// </summary>
         public string FilePath { get; set; }
-
-        /// <summary>
-        /// 指摘一覧
-        /// </summary>
-        public IList<Issue> Issues { get; } = new List<Issue>();
-
+        
         /// <summary>
         /// 作成者
         /// </summary>
@@ -159,6 +154,11 @@ namespace ReviewFileToJsonService.Models
         public string IssueCountOfActual { get; set; }
 
         #endregion
+
+        /// <summary>
+        /// 指摘一覧
+        /// </summary>
+        public IList<Issue> Issues { get; } = new List<Issue>();
 
         #endregion
     }

--- a/src/ReviewFileToJsonService/Models/Review.cs
+++ b/src/ReviewFileToJsonService/Models/Review.cs
@@ -7,9 +7,9 @@ using ReviewFileToJsonService.Extensions;
 
 namespace ReviewFileToJsonService.Models
 {
-	/// <summary>
-	/// レビュー
-	/// </summary>
+    /// <summary>
+    /// レビュー
+    /// </summary>
     public class Review 
     {
         #region 構築
@@ -18,25 +18,25 @@ namespace ReviewFileToJsonService.Models
         /// コンストラクタ
         /// </summary>
         public Review() 
-		{
-		}
+        {
+        }
 
-		/// <summary>
-		/// コンストラクタ
-		/// </summary>
-		/// <param name="reviewModel"></param>
-		public Review(IReview reviewModel)
-		{
-			// 同じ名前のフィールドをコピー
-			this.CopyFieldsFrom(reviewModel);
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="reviewModel"></param>
+        public Review(IReview reviewModel)
+        {
+            // 同じ名前のフィールドをコピー
+            this.CopyFieldsFrom(reviewModel);
 
-			// 指摘をコピー
-			foreach ( var issueModel in reviewModel.Issues)
-			{
-				var issue = new Issue(issueModel);
-				Issues.Add(issue);
+            // 指摘をコピー
+            foreach ( var issueModel in reviewModel.Issues)
+            {
+                var issue = new Issue(issueModel);
+                Issues.Add(issue);
             }
-		}
+        }
 
         #endregion
 
@@ -72,7 +72,7 @@ namespace ReviewFileToJsonService.Models
         /// </summary>
         public DateTime? LastUpdatedDateTime { get; set; }
 
-	    #region 基本設定タブ
+        #region 基本設定タブ
 
         /// <summary>
         /// レビュー名

--- a/src/ReviewFileToJsonService/Models/Review.cs
+++ b/src/ReviewFileToJsonService/Models/Review.cs
@@ -72,7 +72,7 @@ namespace ReviewFileToJsonService.Models
         /// </summary>
         public DateTime? LastUpdatedDateTime { get; set; }
 
-        #region 基本設定タブ
+        #region 基本設定
 
         /// <summary>
         /// レビュー名
@@ -106,7 +106,7 @@ namespace ReviewFileToJsonService.Models
 
         #endregion
 
-        #region 予実タブ
+        #region 予実
 
         /// <summary>
         /// 計画実施日

--- a/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
+++ b/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
@@ -16,6 +16,9 @@ namespace LightningReview.ReviewFileToJsonService
     /// </summary>
     public class ReviewFileToJsonExporter
     {
+        /// <summary>
+        /// ログ出力
+        /// </summary>
         public Action<string> Logger { get; set; }
 
         /// <summary>

--- a/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
+++ b/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
@@ -21,28 +21,32 @@ namespace LightningReview.ReviewFileToJsonService
         /// <summary>
         /// 指定フォルダのレビューファイルを集計してJSONファイルに出力する
         /// </summary>
-        /// <param name="revxFolder"></param>
-        /// <param name="outputFilePath"></param>
-        /// <param name="includeSubFolders"></param>
-        public void Export(string revxFolder,string outputFilePath,bool includeSubFolders=false)
+        /// <param name="revxFolder">レビューファイルが格納されたフォルダ</param>
+        /// <param name="outputFilePath">出力ファイルのパス</param>
+        /// <param name="includeSubFolders">サブフォルダも含めるか</param>
+        /// <param name="unescapedUnicode">Unicodeエスケープを防ぐか</param>
+        public void Export(string revxFolder, string outputFilePath, bool includeSubFolders = false, bool unescapedUnicode = false)
         {
             var reader = new ReviewFileReader();
             var readReviews = reader.ReadFolder(revxFolder, includeSubFolders);
             // Jsonモデル
             var jsonModel = new JsonModel(readReviews);
-            
+
             // シリアライズ時のオプション設定
             var options = new JsonSerializerOptions()
+            {
+                // 読みやすいようにインデントを付与する
+                WriteIndented = true
+            };
+
+            if (unescapedUnicode)
             {
                 // JSONファイル内の日本語をUnicodeエスケープされないようにすることで
                 // UTF-8でエンコードされたJSONファイルとして出力される
                 // 出力されたJSONファイルを別ツールを用いて読み込む場合にUTF-8以外で
                 // 読み込もうとすると日本語が文字化けしてしまうため、UTF-8で読み込むこと
-	            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
-
-                // 読みやすいようにインデントを付与する
-                WriteIndented = true,
-            };
+                options.Encoder = JavaScriptEncoder.Create(UnicodeRanges.All);
+            }
 
             // ログ出力
             Logger?.Invoke($"{readReviews.Count()}件のレビューファイルが見つかりました。");

--- a/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
+++ b/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 
 namespace LightningReview.ReviewFileToJsonService
 {
@@ -28,9 +30,17 @@ namespace LightningReview.ReviewFileToJsonService
             var readReviews = reader.ReadFolder(revxFolder, includeSubFolders);
             // Jsonモデル
             var jsonModel = new JsonModel(readReviews);
-
+            
+            // シリアライズ時のオプション設定
             var options = new JsonSerializerOptions()
             {
+                // JSONファイル内の日本語をUnicodeエスケープされないようにすることで
+                // UTF-8でエンコードされたJSONファイルとして出力される
+                // 出力されたJSONファイルを別ツールを用いて読み込む場合にUTF-8以外で
+                // 読み込もうとすると日本語が文字化けしてしまうため、UTF-8で読み込むこと
+	            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+
+                // 読みやすいようにインデントを付与する
                 WriteIndented = true,
             };
 
@@ -41,6 +51,5 @@ namespace LightningReview.ReviewFileToJsonService
             var jsonString = JsonSerializer.Serialize(jsonModel, options);
             File.WriteAllText(outputFilePath, jsonString);
         }
-
     }
 }

--- a/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
+++ b/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
@@ -24,8 +24,8 @@ namespace LightningReview.ReviewFileToJsonService
         /// <param name="includeSubFolders"></param>
         public void Export(string revxFolder,string outputFilePath,bool includeSubFolders=false)
         {
-			var reader = new ReviewFileReader();
-			var readReviews = reader.ReadFolder(revxFolder, includeSubFolders);
+            var reader = new ReviewFileReader();
+            var readReviews = reader.ReadFolder(revxFolder, includeSubFolders);
             // Jsonモデル
             var jsonModel = new JsonModel(readReviews);
 
@@ -39,7 +39,7 @@ namespace LightningReview.ReviewFileToJsonService
 
             // JSONとして書き出しする
             var jsonString = JsonSerializer.Serialize(jsonModel, options);
-			File.WriteAllText(outputFilePath, jsonString);
+            File.WriteAllText(outputFilePath, jsonString);
         }
 
     }

--- a/src/ReviewFileToJsonService/ReviewFileToJsonService.csproj
+++ b/src/ReviewFileToJsonService/ReviewFileToJsonService.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 

--- a/src/ReviewFileToJsonService/ReviewFileToJsonService.csproj
+++ b/src/ReviewFileToJsonService/ReviewFileToJsonService.csproj
@@ -13,13 +13,13 @@
     <RepositoryType>github</RepositoryType>
     <PackageProjectUrl>https://github.com/denso-create/LightningReview-ReviewFile</PackageProjectUrl>
     <PackageId>LightningReview.ReviewFileToJsonService</PackageId>
-    <PackageVersion>0.8.6</PackageVersion>
-    <Version>0.8.6</Version>
+    <PackageVersion>0.8.7</PackageVersion>
+    <Version>0.8.7</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>Modelのフィールドを拡充</PackageReleaseNotes>
-    <AssemblyVersion>0.8.6.0</AssemblyVersion>
-    <FileVersion>0.8.6.0</FileVersion>
+    <PackageReleaseNotes>ドキュメントおよびコメントの拡充と推敲を行った</PackageReleaseNotes>
+    <AssemblyVersion>0.8.7.0</AssemblyVersion>
+    <FileVersion>0.8.7.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
## 変更概要
ドキュメントやコメントの拡充と見直しを行った。
タブ使用箇所を半角スペースに置換するなどの細かい修正以外に下記3点に対応した。

### Readme.mdの拡充
CLIでのJSONの出力フォーマットの説明の拡充 579ef21a3ab15dbdd5921498c45d9db917231b0b
ReviewやIssueの要素にアクセスする例の拡充 639bda0fee16fbbc2264ed9cdc2ec5ade7b22610

### JSONの出力オプションを日本語がUnicodeエスケープされないように変更
出力オプションとしてUnicodeエスケープを切り替えられるように変更
- ReviewFileToJsonExporter.Exportの引数にunescapedUnicodeを追加およびCLIのオプションに追加 9fa9380620df50c92fd87263679da85b889d66ac
- Readmeに追記 2a5e1f22afedae7ea767c6b1d451d79379d27536 

### XMLコメントがなく警告を受けている件の解消
publish-nugetを実行している際に警告がされておりその解消を行う 
ActionのAnnotations参照： https://github.com/denso-create/LightningReview-ReviewFile/actions/runs/592384079
警告を受けていたXMLコメントがない箇所のサマリーを記載しました 4e8ec5f33b2ff2c17cf7cc89b0fe59bd50f1c173 2c8ff5fb0d5392ce8203b080e7a4e1aa9750e835 0425fbd41da7989977fac32a7eed8119ba1cc588