### PR TITLE
出力ファイルパスの入力チェックを追加

### DIFF
--- a/src/ReviewFileToJsonCLI/Program.cs
+++ b/src/ReviewFileToJsonCLI/Program.cs
@@ -57,8 +57,21 @@ namespace ReviewFileToJson
 
             // 出力先のファイルが指定なければ設定する
             var outputPath = parsed.Value.OutputPath;
-            if ( string.IsNullOrEmpty(outputPath) ) {
+            if (string.IsNullOrEmpty(outputPath))
+            {
                 outputPath = "output.json";
+            }
+            else if (Path.GetExtension(outputPath) == string.Empty)
+            {
+	            Console.WriteLine($"エラー：指定した出力ファイル{outputPath}に拡張子を設定してください。");
+	            return;
+            }
+
+            var outputFolderPath = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(outputFolderPath) && !Directory.Exists(outputFolderPath))
+            {
+	            Console.WriteLine($"エラー：指定した出力ファイル{outputPath}のフォルダが存在しません。");
+	            return;
             }
 
             // サブフォルダを含む


### PR DESCRIPTION
## 変更概要
ReviewFileToJsonCLIのProgramに出力ファイルパスが下記の2パターンであった場合にエラーメッセージを表示させ終了する
- 指定した出力ファイルパス中に存在しないフォルダを含まれている場合に
「指定した出力ファイル"xxx\xxx\xxx"のフォルダが存在しません。」と表示する
- 指定した出力ファイルパスに拡張子が存在しない場合に
「エラー：指定した出力ファイル"xxx\xxx\xxx"に拡張子を設定してください。」と表示する