### PR TITLE
Linuxで動作させるため、グローバリゼーションのランタイム構成オプションを不変モードとする。

### DIFF
--- a/src/ReviewFileToJsonCLI/ReviewFileToJsonCLI.csproj
+++ b/src/ReviewFileToJsonCLI/ReviewFileToJsonCLI.csproj
@@ -20,4 +20,8 @@
     <ProjectReference Include="..\ReviewFileToJsonService\ReviewFileToJsonService.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## 変更概要
国際化対応をサポートするライブラリ(ICU)がLinux環境でインストールされていない場合に、LinuxでReviewFileToJsonCLIが正常実行できないため、設定としてカルチャデータを利用しない不変モードとする。

不変モードに設定する方法はエラーの内容を調査し、最終的にMicrosoftがNET Core アプリを展開する際に対象がLinuxであれば検討するとしている方法で設定しました。
https://docs.microsoft.com/ja-jp/dotnet/core/deploying/deploy-with-vs?tabs=vs156#self-contained-deployment-without-third-party-dependencies
[3.グローバリゼーション インバリアント モードを使用するかどうかを決定します。]の箇所

不変モードの設定にした場合の影響点は下記を参照ください。
https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md