### PR TITLE
改訂されたC#コーディングルールを受け、名前空間の修正対応

### DIFF
--- a/src/ReviewFile.Tests/Base/TestBase.cs
+++ b/src/ReviewFile.Tests/Base/TestBase.cs
@@ -1,4 +1,4 @@
-﻿using LightningReview.ReviewFile.Models;
+﻿using DensoCreate.LightningReview.ReviewFile.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -8,7 +8,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LightningReview.ReviewFile.Tests
+namespace DensoCreate.LightningReview.ReviewFile.Tests
 {
     public class TestBase
     {

--- a/src/ReviewFile.Tests/ReviewFileReaderPeformanceTest.cs
+++ b/src/ReviewFile.Tests/ReviewFileReaderPeformanceTest.cs
@@ -1,11 +1,11 @@
-﻿using LightningReview.ReviewFile.Models;
+﻿using DensoCreate.LightningReview.ReviewFile.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
-namespace LightningReview.ReviewFile.Tests
+namespace DensoCreate.LightningReview.ReviewFile.Tests
 {
     /// <summary>
     /// ReviewFileReaderクラスのパフォーマンステスト

--- a/src/ReviewFile.Tests/ReviewFileReaderTests.cs
+++ b/src/ReviewFile.Tests/ReviewFileReaderTests.cs
@@ -1,13 +1,13 @@
-using LightningReview.ReviewFile.Models;
+using DensoCreate.LightningReview.ReviewFile.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using LightningReview.ReviewFile.Exceptions;
+using DensoCreate.LightningReview.ReviewFile.Exceptions;
 
-namespace LightningReview.ReviewFile.Tests
+namespace DensoCreate.LightningReview.ReviewFile.Tests
 {
     /// <summary>
     /// ReviewFileReaderクラスのテスト

--- a/src/ReviewFile/Exceptions/RevxFormatException.cs
+++ b/src/ReviewFile/Exceptions/RevxFormatException.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace LightningReview.ReviewFile.Exceptions
+namespace DensoCreate.LightningReview.ReviewFile.Exceptions
 {
     /// <summary>
     /// ReviewFileで使用する例外クラス

--- a/src/ReviewFile/IReviewFileReader.cs
+++ b/src/ReviewFile/IReviewFileReader.cs
@@ -20,11 +20,25 @@ namespace DensoCreate.LightningReview.ReviewFile
         IReview Read(string filePath);
 
         /// <summary>
+        /// レビューファイルのストリームを読み込みます。
+        /// </summary>
+        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
+        /// <returns>ロードしたレビューモデル</returns>
+        IReview Read(Stream reviewFileStream);
+
+        /// <summary>
         /// 非同期で指定ファイルのレビューファイルを読み込みます。
         /// </summary>
         /// <param name="filePath">レビューファイルのパス</param>
         /// <returns>ロードしたレビューモデル</returns>
         Task<IReview> ReadAsync(string filePath);
+
+        /// <summary>
+        /// 非同期でレビューファイルのストリームを読み込みます。
+        /// </summary>
+        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
+        /// <returns>ロードしたレビューモデル</returns>
+        Task<IReview> ReadAsync(Stream reviewFileStream);
 
         /// <summary>
         /// 指定フォルダのレビューファイルを読み込みます。
@@ -41,19 +55,5 @@ namespace DensoCreate.LightningReview.ReviewFile
         /// <param name="includeSubFodler">サブフォルダも対象にするか</param>
         /// <returns>ロードしたレビューモデル</returns>
         Task<IEnumerable<IReview>> ReadFolderAsync(string folderPath, bool includeSubFodler = false);
-
-        /// <summary>
-        /// レビューファイルのストリームを読み込みます。
-        /// </summary>
-        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
-        /// <returns>ロードしたレビューモデル</returns>
-        IReview Read(Stream reviewFileStream);
-
-        /// <summary>
-        /// 非同期でレビューファイルのストリームを読み込みます。
-        /// </summary>
-        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
-        /// <returns>ロードしたレビューモデル</returns>
-        Task<IReview> ReadAsync(Stream reviewFileStream);
     }
 }

--- a/src/ReviewFile/IReviewFileReader.cs
+++ b/src/ReviewFile/IReviewFileReader.cs
@@ -1,11 +1,11 @@
-﻿using LightningReview.ReviewFile.Models;
+﻿using DensoCreate.LightningReview.ReviewFile.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace LightningReview.ReviewFile
+namespace DensoCreate.LightningReview.ReviewFile
 {
     /// <summary>
     /// レビューファイルのリーダーのインタフェース

--- a/src/ReviewFile/Models/IDocument.cs
+++ b/src/ReviewFile/Models/IDocument.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace LightningReview.ReviewFile.Models
+namespace DensoCreate.LightningReview.ReviewFile.Models
 {
     /// <summary>
     /// ドキュメントのインタフェース

--- a/src/ReviewFile/Models/IIssue.cs
+++ b/src/ReviewFile/Models/IIssue.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace LightningReview.ReviewFile.Models
+namespace DensoCreate.LightningReview.ReviewFile.Models
 {
     /// <summary>
     /// 指摘のインタフェース

--- a/src/ReviewFile/Models/IOutlineNode.cs
+++ b/src/ReviewFile/Models/IOutlineNode.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace LightningReview.ReviewFile.Models
+namespace DensoCreate.LightningReview.ReviewFile.Models
 {
     /// <summary>
     /// アウトラインノードのインタフェース

--- a/src/ReviewFile/Models/IReview.cs
+++ b/src/ReviewFile/Models/IReview.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace LightningReview.ReviewFile.Models
+namespace DensoCreate.LightningReview.ReviewFile.Models
 {
     /// <summary>
     /// レビューのインタフェース

--- a/src/ReviewFile/Models/IReviewFile.cs
+++ b/src/ReviewFile/Models/IReviewFile.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace LightningReview.ReviewFile.Models
+namespace DensoCreate.LightningReview.ReviewFile.Models
 {
     /// <summary>
     /// レビューファイルのインタフェース

--- a/src/ReviewFile/Models/V10/Document.cs
+++ b/src/ReviewFile/Models/V10/Document.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V10
+namespace DensoCreate.LightningReview.ReviewFile.Models.V10
 {
     /// <summary>
     /// ドキュメント

--- a/src/ReviewFile/Models/V10/Issue.cs
+++ b/src/ReviewFile/Models/V10/Issue.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V10
+namespace DensoCreate.LightningReview.ReviewFile.Models.V10
 {
     /// <summary>
     /// 指摘

--- a/src/ReviewFile/Models/V10/OutlineNode.cs
+++ b/src/ReviewFile/Models/V10/OutlineNode.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V10
+namespace DensoCreate.LightningReview.ReviewFile.Models.V10
 {
     /// <summary>
     /// アウトラインノード

--- a/src/ReviewFile/Models/V10/Project.cs
+++ b/src/ReviewFile/Models/V10/Project.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V10
+namespace DensoCreate.LightningReview.ReviewFile.Models.V10
 {
     /// <summary>
     /// プロジェクト

--- a/src/ReviewFile/Models/V10/Review.cs
+++ b/src/ReviewFile/Models/V10/Review.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V10
+namespace DensoCreate.LightningReview.ReviewFile.Models.V10
 {
     /// <summary>
     /// レビュー

--- a/src/ReviewFile/Models/V10/ReviewFile.cs
+++ b/src/ReviewFile/Models/V10/ReviewFile.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V10
+namespace DensoCreate.LightningReview.ReviewFile.Models.V10
 {
     /// <summary>
     /// レビューファイル

--- a/src/ReviewFile/Models/V18/Defenitions/Defenition.cs
+++ b/src/ReviewFile/Models/V18/Defenitions/Defenition.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18.Defenitions
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18.Defenitions
 {
     /// <summary>
     /// 定義

--- a/src/ReviewFile/Models/V18/Defenitions/FieldDefenition.cs
+++ b/src/ReviewFile/Models/V18/Defenitions/FieldDefenition.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18.Defenitions
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18.Defenitions
 {
     /// <summary>
     /// フィールド定義

--- a/src/ReviewFile/Models/V18/Defenitions/IssueDefenition.cs
+++ b/src/ReviewFile/Models/V18/Defenitions/IssueDefenition.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18.Defenitions
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18.Defenitions
 {
     /// <summary>
     /// 指摘の定義

--- a/src/ReviewFile/Models/V18/Document.cs
+++ b/src/ReviewFile/Models/V18/Document.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Xml.Serialization;
 using System.Linq;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// ドキュメント

--- a/src/ReviewFile/Models/V18/Documents.cs
+++ b/src/ReviewFile/Models/V18/Documents.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// ドキュメントの一覧

--- a/src/ReviewFile/Models/V18/EntityBase.cs
+++ b/src/ReviewFile/Models/V18/EntityBase.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// 各エンティティに共通する基底クラス

--- a/src/ReviewFile/Models/V18/EntityBase.cs
+++ b/src/ReviewFile/Models/V18/EntityBase.cs
@@ -15,7 +15,7 @@ namespace DensoCreate.LightningReview.ReviewFile.Models.V18
         /// <summary>
         /// コンストラクタ
         /// </summary>
-        public EntityBase()
+        protected EntityBase()
         {
             GID = Guid.NewGuid().ToString();
         }

--- a/src/ReviewFile/Models/V18/Issue.cs
+++ b/src/ReviewFile/Models/V18/Issue.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// 指摘

--- a/src/ReviewFile/Models/V18/Issues.cs
+++ b/src/ReviewFile/Models/V18/Issues.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// 指摘の一覧

--- a/src/ReviewFile/Models/V18/OutlineNode.cs
+++ b/src/ReviewFile/Models/V18/OutlineNode.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// アウトラインノード

--- a/src/ReviewFile/Models/V18/OutlineTree.cs
+++ b/src/ReviewFile/Models/V18/OutlineTree.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// アウトラインツリー

--- a/src/ReviewFile/Models/V18/Project.cs
+++ b/src/ReviewFile/Models/V18/Project.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// プロジェクト

--- a/src/ReviewFile/Models/V18/Review.cs
+++ b/src/ReviewFile/Models/V18/Review.cs
@@ -35,7 +35,7 @@ namespace DensoCreate.LightningReview.ReviewFile.Models.V18
                     issues.AddRange(doc.AllIssues);
                 }
 
-                return issues.ToList();
+                return issues;
             }
         }
 

--- a/src/ReviewFile/Models/V18/Review.cs
+++ b/src/ReviewFile/Models/V18/Review.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 using System.Linq;
-using LightningReview.ReviewFile.Models.V18.Defenitions;
+using DensoCreate.LightningReview.ReviewFile.Models.V18.Defenitions;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// レビュー

--- a/src/ReviewFile/Models/V18/ReviewFile.cs
+++ b/src/ReviewFile/Models/V18/ReviewFile.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// レビューファイル

--- a/src/ReviewFile/Models/V18/Settings/ReviewSettings.cs
+++ b/src/ReviewFile/Models/V18/Settings/ReviewSettings.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace LightningReview.ReviewFile.Models.V18
+namespace DensoCreate.LightningReview.ReviewFile.Models.V18
 {
     /// <summary>
     /// レビュー設定

--- a/src/ReviewFile/ReviewFile.csproj
+++ b/src/ReviewFile/ReviewFile.csproj
@@ -11,16 +11,16 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>LightningReview.ReviewFile</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
-    <Version>1.0.0</Version>
+    <PackageVersion>1.0.4</PackageVersion>
+    <Version>1.0.4</Version>
     <Authors>DENSO CREATE INC.</Authors>
     <Company>DENSO CREATE INC.</Company>
     <RepositoryUrl>https://github.com/denso-create/LightningReview-ReviewFile</RepositoryUrl>
     <RepositoryType>github</RepositoryType>
     <PackageProjectUrl>https://github.com/denso-create/LightningReview-ReviewFile</PackageProjectUrl>
-    <PackageReleaseNotes>フレームワークおよび依存パッケージの情報を整理</PackageReleaseNotes>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <PackageReleaseNotes>名前空間のリファクタリング</PackageReleaseNotes>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4.0</FileVersion>
   </PropertyGroup>
     
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/ReviewFile/ReviewFileReader.cs
+++ b/src/ReviewFile/ReviewFileReader.cs
@@ -48,30 +48,30 @@ namespace DensoCreate.LightningReview.ReviewFile
         /// <returns>ロードしたレビューモデル</returns>
         public IReview Read(Stream reviewFileStream)
         {
-	        try
-	        {
-		        // スキーマバージョン値を取得
-		        var xDoc = XDocument.Load(reviewFileStream);
-		        var xElement = xDoc.Element("ReviewFile");
-		        if (xElement == null) throw new ReviewFileFormatException("ReviewFile Element Missing");
-		        var schemeVersion = double.Parse(xElement.Element("SchemaVersion").Value);
+            try
+            {
+                // スキーマバージョン値を取得
+                var xDoc = XDocument.Load(reviewFileStream);
+                var xElement = xDoc.Element("ReviewFile");
+                if (xElement == null) throw new ReviewFileFormatException("ReviewFile Element Missing");
+                var schemeVersion = double.Parse(xElement.Element("SchemaVersion").Value);
 
-		        // デシリアライズする
-		        // スキーマが1.7以降はV1.8のモデルになる
-		        var serializer = schemeVersion >= 1.7
-			        ? new XmlSerializer(typeof(Models.V18.ReviewFile))
-			        : new XmlSerializer(typeof(Models.V10.ReviewFile));
-		        var reviewFile = (IReviewFile) serializer.Deserialize(xDoc.CreateReader());
+                // デシリアライズする
+                // スキーマが1.7以降はV1.8のモデルになる
+                var serializer = schemeVersion >= 1.7
+                    ? new XmlSerializer(typeof(Models.V18.ReviewFile))
+                    : new XmlSerializer(typeof(Models.V10.ReviewFile));
+                var reviewFile = (IReviewFile)serializer.Deserialize(xDoc.CreateReader());
 
-		        // Streamを指定しており、この時点ではファイルパスが特定できないため空文字とする
-		        reviewFile.Review.FilePath = string.Empty;
-                
-		        return reviewFile.Review;
-	        }
-	        catch (Exception ex)
-	        {
-		        throw new ReviewFileFormatException(ex.Message, ex);
-	        }
+                // Streamを指定しており、この時点ではファイルパスが特定できないため空文字とする
+                reviewFile.Review.FilePath = string.Empty;
+
+                return reviewFile.Review;
+            }
+            catch (Exception ex)
+            {
+                throw new ReviewFileFormatException(ex.Message, ex);
+            }
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace DensoCreate.LightningReview.ReviewFile
         {
             return await Task.Run(() => Read(filePath));
         }
-        
+
         /// <summary>
         /// 非同期でストリームからロードします。
         /// </summary>
@@ -91,7 +91,7 @@ namespace DensoCreate.LightningReview.ReviewFile
         /// <returns>ロードしたレビューモデル</returns>
         public async Task<IReview> ReadAsync(Stream reviewFileStream)
         {
-	        return await Task.Run(() => Read(reviewFileStream));
+            return await Task.Run(() => Read(reviewFileStream));
         }
 
         /// <summary>

--- a/src/ReviewFile/ReviewFileReader.cs
+++ b/src/ReviewFile/ReviewFileReader.cs
@@ -42,6 +42,39 @@ namespace DensoCreate.LightningReview.ReviewFile
         }
 
         /// <summary>
+        /// ストリームからロードします。
+        /// </summary>
+        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
+        /// <returns>ロードしたレビューモデル</returns>
+        public IReview Read(Stream reviewFileStream)
+        {
+	        try
+	        {
+		        // スキーマバージョン値を取得
+		        var xDoc = XDocument.Load(reviewFileStream);
+		        var xElement = xDoc.Element("ReviewFile");
+		        if (xElement == null) throw new ReviewFileFormatException("ReviewFile Element Missing");
+		        var schemeVersion = double.Parse(xElement.Element("SchemaVersion").Value);
+
+		        // デシリアライズする
+		        // スキーマが1.7以降はV1.8のモデルになる
+		        var serializer = schemeVersion >= 1.7
+			        ? new XmlSerializer(typeof(Models.V18.ReviewFile))
+			        : new XmlSerializer(typeof(Models.V10.ReviewFile));
+		        var reviewFile = (IReviewFile) serializer.Deserialize(xDoc.CreateReader());
+
+		        // Streamを指定しており、この時点ではファイルパスが特定できないため空文字とする
+		        reviewFile.Review.FilePath = string.Empty;
+                
+		        return reviewFile.Review;
+	        }
+	        catch (Exception ex)
+	        {
+		        throw new ReviewFileFormatException(ex.Message, ex);
+	        }
+        }
+
+        /// <summary>
         /// 非同期でファイルからロードします。
         /// </summary>
         /// <param name="filePath">レビューファイルのパス</param>
@@ -49,6 +82,16 @@ namespace DensoCreate.LightningReview.ReviewFile
         public async Task<IReview> ReadAsync(string filePath)
         {
             return await Task.Run(() => Read(filePath));
+        }
+        
+        /// <summary>
+        /// 非同期でストリームからロードします。
+        /// </summary>
+        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
+        /// <returns>ロードしたレビューモデル</returns>
+        public async Task<IReview> ReadAsync(Stream reviewFileStream)
+        {
+	        return await Task.Run(() => Read(reviewFileStream));
         }
 
         /// <summary>
@@ -62,7 +105,7 @@ namespace DensoCreate.LightningReview.ReviewFile
             // 指定したフォルダ以下（サブフォルダ以下も含めて）に存在するすべてのレビューファイルを取得する
             if (Directory.Exists(folderPath) == false)
             {
-                throw new Exception($"{folderPath} is not a valid directory.");
+                throw new ReviewFileFormatException($"{folderPath} is not a valid directory.");
             }
 
             // 指定されたフォルダ以下のレビューファイルに対して、レビューのデータを取得する
@@ -88,49 +131,6 @@ namespace DensoCreate.LightningReview.ReviewFile
         public async Task<IEnumerable<IReview>> ReadFolderAsync(string folderPath, bool includeSubFodler = false)
         {
             return await Task.Run(() => ReadFolder(folderPath, includeSubFodler));
-        }
-
-        /// <summary>
-        /// ストリームからロードします。
-        /// </summary>
-        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
-        /// <returns>ロードしたレビューモデル</returns>
-        public IReview Read(Stream reviewFileStream)
-        {
-            try
-            {
-                // スキーマバージョン値を取得
-                var xDoc = XDocument.Load(reviewFileStream);
-                var xElement = xDoc.Element("ReviewFile");
-                if (xElement == null) throw new ReviewFileFormatException("ReviewFile Element Missing");
-                var schemeVersion = double.Parse(xElement.Element("SchemaVersion").Value);
-
-                // デシリアライズする
-                // スキーマが1.7以降はV1.8のモデルになる
-                var serializer = schemeVersion >= 1.7
-                    ? new XmlSerializer(typeof(Models.V18.ReviewFile))
-                    : new XmlSerializer(typeof(Models.V10.ReviewFile));
-                var reviewFile = (IReviewFile) serializer.Deserialize(xDoc.CreateReader());
-
-                // Streamを指定しており、この時点ではファイルパスが特定できないため空文字とする
-                reviewFile.Review.FilePath = string.Empty;
-                
-                return reviewFile.Review;
-            }
-            catch (Exception ex)
-            {
-                throw new ReviewFileFormatException(ex.Message, ex);
-            }
-        }
-
-        /// <summary>
-        /// 非同期でストリームからロードします。
-        /// </summary>
-        /// <param name="reviewFileStream">レビューファイルのストリーム</param>
-        /// <returns>ロードしたレビューモデル</returns>
-        public async Task<IReview> ReadAsync(Stream reviewFileStream)
-        {
-            return await Task.Run(() => Read(reviewFileStream));
         }
     }
 }

--- a/src/ReviewFile/ReviewFileReader.cs
+++ b/src/ReviewFile/ReviewFileReader.cs
@@ -2,16 +2,16 @@
 using System.Collections.Generic;
 using System.Text;
 using System.IO.Compression;
-using LightningReview.ReviewFile.Models;
+using DensoCreate.LightningReview.ReviewFile.Models;
 using System.Xml.Serialization;
 using System.Xml;
 using System.Threading.Tasks;
 using System.IO;
 using System.Xml.Linq;
 using System.Linq;
-using LightningReview.ReviewFile.Exceptions;
+using DensoCreate.LightningReview.ReviewFile.Exceptions;
 
-namespace LightningReview.ReviewFile
+namespace DensoCreate.LightningReview.ReviewFile
 {
     /// <summary>
     /// レビューファイルのリーダー

--- a/src/ReviewFileToJsonCLI/Program.cs
+++ b/src/ReviewFileToJsonCLI/Program.cs
@@ -1,12 +1,12 @@
 ﻿using CommandLine;
-using LightningReview.ReviewFileToJsonService;
+using DensoCreate.LightningReview.ReviewFileToJsonService;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 
-namespace ReviewFileToJson
+namespace DensoCreate.LightningReview.ReviewFileToJson
 {
     class Program
     {

--- a/src/ReviewFileToJsonService.Tests/ReviewFileToJsonExporterTests.cs
+++ b/src/ReviewFileToJsonService.Tests/ReviewFileToJsonExporterTests.cs
@@ -1,4 +1,4 @@
-using LightningReview.ReviewFileToJsonService;
+using DensoCreate.LightningReview.ReviewFileToJsonService;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
-namespace ReviewFileToJsonService.Tests
+namespace DensoCreate.LightningReview.ReviewFileToJsonService.Tests
 {
     /// <summary>
     /// ReviewFileToJsonExporterクラスのテスト

--- a/src/ReviewFileToJsonService/Extensionis/JsonModelExtension.cs
+++ b/src/ReviewFileToJsonService/Extensionis/JsonModelExtension.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 
-namespace ReviewFileToJsonService.Extensions
+namespace DensoCreate.LightningReview.ReviewFileToJsonService.Extensions
 {
     internal static class FieldCopyHelper
     {

--- a/src/ReviewFileToJsonService/Models/Issue.cs
+++ b/src/ReviewFileToJsonService/Models/Issue.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using LightningReview.ReviewFile.Models;
-using ReviewFileToJsonService.Extensions;
+using DensoCreate.LightningReview.ReviewFile.Models;
+using DensoCreate.LightningReview.ReviewFileToJsonService.Extensions;
 
-namespace ReviewFileToJsonService.Models
+namespace DensoCreate.LightningReview.ReviewFileToJsonService
 {
     /// <summary>
     /// 指摘

--- a/src/ReviewFileToJsonService/Models/JsonModel.cs
+++ b/src/ReviewFileToJsonService/Models/JsonModel.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using LightningReview.ReviewFile.Models;
-using ReviewFileToJsonService.Extensions;
+using DensoCreate.LightningReview.ReviewFile.Models;
+using DensoCreate.LightningReview.ReviewFileToJsonService.Extensions;
 
-namespace ReviewFileToJsonService.Models
+namespace DensoCreate.LightningReview.ReviewFileToJsonService
 {
     /// <summary>
     /// JSONファイルのルートオブジェクト

--- a/src/ReviewFileToJsonService/Models/Review.cs
+++ b/src/ReviewFileToJsonService/Models/Review.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using LightningReview.ReviewFile.Models;
-using ReviewFileToJsonService.Extensions;
+using DensoCreate.LightningReview.ReviewFile.Models;
+using DensoCreate.LightningReview.ReviewFileToJsonService.Extensions;
 
-namespace ReviewFileToJsonService.Models
+namespace DensoCreate.LightningReview.ReviewFileToJsonService
 {
     /// <summary>
     /// レビュー

--- a/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
+++ b/src/ReviewFileToJsonService/ReviewFileToJsonExporter.cs
@@ -1,5 +1,5 @@
-﻿using LightningReview.ReviewFile;
-using ReviewFileToJsonService.Models;
+﻿using DensoCreate.LightningReview.ReviewFile;
+using DensoCreate.LightningReview.ReviewFileToJsonService;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,7 +9,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
 
-namespace LightningReview.ReviewFileToJsonService
+namespace DensoCreate.LightningReview.ReviewFileToJsonService
 {
     /// <summary>
     /// RevxのJsonエクスポート

--- a/src/ReviewFileToJsonService/ReviewFileToJsonService.csproj
+++ b/src/ReviewFileToJsonService/ReviewFileToJsonService.csproj
@@ -13,13 +13,13 @@
     <RepositoryType>github</RepositoryType>
     <PackageProjectUrl>https://github.com/denso-create/LightningReview-ReviewFile</PackageProjectUrl>
     <PackageId>LightningReview.ReviewFileToJsonService</PackageId>
-    <PackageVersion>1.0.3</PackageVersion>
-    <Version>1.0.3</Version>
+    <PackageVersion>1.0.4</PackageVersion>
+    <Version>1.0.4</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>利用ライブラリのバージョンを更新</PackageReleaseNotes>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3.0</FileVersion>
+    <PackageReleaseNotes>名前空間のリファクタリング</PackageReleaseNotes>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
## 変更概要
改訂されたC#コーディングルールを受け、名前空間の修正対応を行いました。
また、ライブラリの更新を行うためパッケージバージョンを更新しました。

- 公開ライブラリの名前空間は1つに統一する。ソースファイルをフォルダで整理していても名前空間は分けない。
ライブラリ内に存在するユーザに公開しているがフォルダ構造の名前空間になっていたファイルについて修正した。
LightningReview-ReviewFile/src/ReviewFileToJsonService/Models 以下の3ファイル
[Issue.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/main/src/ReviewFileToJsonService/Models/Issue.cs)
[JsonModel.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/main/src/ReviewFileToJsonService/Models/JsonModel.cs)
[Review.cs](https://github.com/denso-create/LightningReview-ReviewFile/blob/main/src/ReviewFileToJsonService/Models/Review.cs)

- 他から参照しないアプリケーション内の名前空間はフォルダ構造に合わせる。
以下はVersion1.0と1.8のモデルを同じクラス名で表す必要があるため、名前空間を分ける必要がある。
そのためpublicだが、名前空間を区別するようにしている。なお、これらのクラスはユーザに公開する目的のクラスではないため、ユーザの利便性には問題ない。
[LightningReview-ReviewFile/src/ReviewFile/Models/V10](https://github.com/denso-create/LightningReview-ReviewFile/tree/main/src/ReviewFile/Models/V10)
[LightningReview-ReviewFile/src/ReviewFile/Models/V18](https://github.com/denso-create/LightningReview-ReviewFile/tree/main/src/ReviewFile/Models/V18)

また、名称の先頭に"DensoCreate"を付ける規則に則っていなかったため、"DensoCreate"を付けるように修正している。